### PR TITLE
Simplify Bundle.ML object construction.

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -107,5 +107,5 @@ case class Bundle(name: String,
   def bundleContext(bundleRegistry: BundleRegistry,
                     path: File): BundleContext = BundleContext(this.format, bundleRegistry, path)
 
-  override def replaceAttrList(list: AttributeList): Bundle = copy(attributes = Some(list))
+  override def replaceAttrList(list: Option[AttributeList]): Bundle = copy(attributes = list)
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Model.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Model.scala
@@ -3,99 +3,6 @@ package ml.combust.bundle.dsl
 import ml.bundle.ModelDef.ModelDef
 import ml.combust.bundle.serializer.SerializationContext
 
-/** Trait for read-only operations on a [[Model]].
-  *
-  * Use this trait to expose a read-only interface to a [[Model]].
-  * This is primarily used when deserializing.
-  */
-trait ReadableModel {
-  /** Convert the [[Model]] to a protobuf serializable object.
-    *
-    * @param context serialization context for encoding custom values
-    * @return protobuf model definition
-    */
-  def bundleModel(implicit context: SerializationContext): ModelDef
-
-  /** Get the op name for this model.
-    *
-    * The op name defines what the model actually is. It corresponds
-    * to an entry for a [[ml.combust.bundle.op.OpNode]] in a [[ml.combust.bundle.serializer.BundleRegistry]].
-    *
-    * [[ml.combust.bundle.op.OpModel]] have all methods and data needed to serialize a model
-    * for a given op name.
-    *
-    * Examples are "linear_regression", "string_indexer", "random_forest_classifier", etc.
-    *
-    * @return op name
-    */
-  def op: String
-
-  /** Get list of attributes for this model.
-    *
-    * @return optional list read-only attribute list
-    */
-  def attributes: Option[ReadableAttributeList]
-
-  /** Get a specific attribute by name.
-    *
-    * Throws an error if the attribute does not exist.
-    *
-    * @param name name of the attribute
-    * @return the attribute
-    */
-  def attr(name: String): Attribute
-
-  /** Get an optional attribute by name.
-    *
-    * @param name name of the attribute
-    * @return an optional attribute
-    */
-  def getAttr(name: String): Option[Attribute]
-
-  /** Get the value of an attribute.
-    *
-    * Throws an error if the attribute does not exist.
-    *
-    * @param name name of the attribute
-    * @return value of the attribute
-    */
-  def value(name: String): Value
-
-  /** Get an optional value for an attribute.
-    *
-    * @param name name of the attribute
-    * @return optional value of the attribute
-    */
-  def getValue(name: String): Option[Value]
-}
-
-/** Trait for a writable interface to a [[Model]].
-  *
-  * Use this trait during serialization of [[Model]] objects.
-  */
-trait WritableModel extends ReadableModel {
-  /** Add an attribute to the model.
-    *
-    * @param attribute attribute to add
-    * @return copy of the model with attribute appended
-    */
-  def withAttr(attribute: Attribute): WritableModel
-
-  /** Add attributes from an attribute list to the model.
-    *
-    * @param list list of attributes to add
-    * @return copy of the model with all attributes appended
-    */
-  def withAttrList(list: AttributeList): WritableModel
-
-  /** Replace all attributes with another list.
-    *
-    * @param list list of attributes used to replace existing attributes
-    * @return copy of model with attributes set to the given list
-    */
-  def replaceAttrList(list: AttributeList): WritableModel
-}
-
 /** Class that encodes all information need to serialize or deserialize
   * a machine learning model.
   *
@@ -104,21 +11,22 @@ trait WritableModel extends ReadableModel {
   * and any other data needed to serialize and deserialize ML models and
   * feature builders.
   *
-  * Usually you will want to pass [[ReadableModel]] or [[WritableModel]] to
-  * a user depending on the use case to constrict the allowed operations.
-  *
   * @param op op name for the model
   * @param attributes optional list of attributes for the model
   */
-case class Model(override val op: String,
-                 override val attributes: Option[AttributeList] = None) extends WritableModel
-  with HasAttributeList[Model] {
-  override def bundleModel(implicit context: SerializationContext): ModelDef = {
+case class Model(op: String,
+                 attributes: Option[AttributeList] = None) extends HasAttributeList[Model] {
+  /** Convert the [[Model]] to a protobuf serializable object.
+    *
+    * @param context serialization context for encoding custom values
+    * @return protobuf model definition
+    */
+  def bundleModel(implicit context: SerializationContext): ModelDef = {
     ModelDef(op = op,
       attributes = attributes.map(_.bundleList))
   }
 
-  override def replaceAttrList(list: AttributeList): Model = {
-    copy(attributes = Some(list))
+  override def replaceAttrList(list: Option[AttributeList]): Model = {
+    copy(attributes = list)
   }
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Node.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Node.scala
@@ -2,42 +2,6 @@ package ml.combust.bundle.dsl
 
 import ml.bundle.NodeDef.NodeDef
 
-/** Trait for read-only interface to a [[Node]].
-  *
-  * Use this trait when deserializing node objects.
-  */
-trait ReadableNode {
-  /** Create a protobuf node definition.
-    *
-    * @return protobuf node definition
-    */
-  def bundleNode: NodeDef
-
-  /** Get the unique name of the node.
-    *
-    * This name must be unique for an entire Bundle.ML model.
-    *
-    * @return name of the node
-    */
-  def name: String
-
-  /** Get the shape of the node.
-    *
-    * The shape defines how to connect input/outputs field
-    * data to the underlying models.
-    *
-    * @return shape of the node
-    */
-  def shape: ReadableShape
-}
-
-/** Trait for writable interface to a [[Node]].
-  *
-  * There are no write operations for a [[Node]].
-  * This trait is just here for completeness.
-  */
-trait WritableNode extends ReadableNode { }
-
 /** Class for storing a node in the Bundle.ML graph.
   *
   * Bundle.ML is composed of a set of [[Node]] objects,
@@ -50,7 +14,11 @@ trait WritableNode extends ReadableNode { }
   * @param name unique identifier for the node
   * @param shape shape of the node
   */
-case class Node(override val name: String,
-                override val shape: Shape) extends WritableNode {
-  override def bundleNode: NodeDef = NodeDef(name = name, shape = Some(shape.bundleShape))
+case class Node(name: String,
+                shape: Shape) {
+  /** Create a protobuf node definition.
+    *
+    * @return protobuf node definition
+    */
+  def bundleNode: NodeDef = NodeDef(name = name, shape = Some(shape.bundleShape))
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/op/OpModel.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/op/OpModel.scala
@@ -1,7 +1,7 @@
 package ml.combust.bundle.op
 
 import ml.combust.bundle.serializer.BundleContext
-import ml.combust.bundle.dsl.{Model, ReadableModel, WritableModel}
+import ml.combust.bundle.dsl.Model
 
 /** Type class for serializing/deserializing ML models to Bundle.ML.
   *
@@ -28,8 +28,8 @@ trait OpModel[M] {
     * @return writable model to be serialized
     */
   def store(context: BundleContext,
-            model: WritableModel,
-            obj: M): WritableModel
+            model: Model,
+            obj: M): Model
 
   /** Load the model.
     *
@@ -41,5 +41,5 @@ trait OpModel[M] {
     * @return reconstructed ML model from the model and context
     */
   def load(context: BundleContext,
-           model: ReadableModel): M
+           model: Model): M
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/op/OpNode.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/op/OpNode.scala
@@ -1,7 +1,7 @@
 package ml.combust.bundle.op
 
 import ml.combust.bundle.serializer.BundleContext
-import ml.combust.bundle.dsl.{ReadableNode, Shape}
+import ml.combust.bundle.dsl.{Node, Shape}
 
 /** Type class for serializing/deserializing Bundle.ML graph nodes.
   *
@@ -43,6 +43,6 @@ trait OpNode[N, M] {
     * @return deserialized node object
     */
   def load(context: BundleContext,
-           node: ReadableNode,
+           node: Node,
            model: M): N
 }

--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/ModelSerializer.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/ModelSerializer.scala
@@ -5,7 +5,7 @@ import java.io.{FileInputStream, FileOutputStream, InputStream, OutputStream}
 import ml.bundle.ModelDef.ModelDef
 import ml.combust.bundle.json.JsonSupport._
 import ml.combust.bundle.serializer.attr.{AttributeListSeparator, AttributeListSerializer}
-import ml.combust.bundle.dsl.{AttributeList, Bundle, Model, WritableModel}
+import ml.combust.bundle.dsl.{AttributeList, Bundle, Model}
 import resource._
 import spray.json._
 
@@ -84,14 +84,14 @@ case class ModelSerializer(context: BundleContext) {
   def write(obj: Any): Unit = {
     context.path.mkdirs()
     val m = context.bundleRegistry.modelForObj[Any](obj)
-    var model: WritableModel = Model(op = m.opName)
+    var model: Model = Model(op = m.opName)
     model = m.store(context, model, obj)
 
     model = context.format match {
       case SerializationFormat.Mixed =>
         val (small, large) = AttributeListSeparator().separate(model.attributes)
         for(l <- large) { AttributeListSerializer(context.file("model.pb")).writeProto(l) }
-        small.map(model.replaceAttrList).getOrElse(model)
+        model.replaceAttrList(small)
       case _ => model
     }
 

--- a/bundle-ml/src/main/scala/ml/combust/bundle/serializer/attr/AttributeListSeparator.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/serializer/attr/AttributeListSeparator.scala
@@ -1,7 +1,7 @@
 package ml.combust.bundle.serializer.attr
 
 import ml.combust.bundle.serializer.HasBundleRegistry
-import ml.combust.bundle.dsl.{Attribute, AttributeList, ReadableAttributeList}
+import ml.combust.bundle.dsl.{Attribute, AttributeList}
 
 /** Class to separate an [[ml.combust.bundle.dsl.AttributeList]] into two
   * [[ml.combust.bundle.dsl.AttributeList]] objects, one with small attributes and one with large.
@@ -19,7 +19,7 @@ case class AttributeListSeparator() {
     * @param hr bundle registry for determining small or large for custom attributes
     * @return an optional small and large attribute list
     */
-  def separate(attributes: Option[ReadableAttributeList])
+  def separate(attributes: Option[AttributeList])
               (implicit hr: HasBundleRegistry): (Option[AttributeList], Option[AttributeList]) = attributes match {
     case None => (None, None)
     case Some(list) =>

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/DecisionTreeRegressionOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/DecisionTreeRegressionOp.scala
@@ -3,7 +3,8 @@ package ml.combust.bundle.test_ops
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.BundleContext
 import ml.combust.bundle.tree.{NodeWrapper, TreeSerializer}
-import ml.combust.bundle.dsl.{Bundle, _}
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.dsl
 
 /**
   * Created by hollinwilkins on 8/22/16.
@@ -85,12 +86,12 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegression, DecisionT
   override val Model: OpModel[DecisionTreeRegressionModel] = new OpModel[DecisionTreeRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.decision_tree_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: DecisionTreeRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: DecisionTreeRegressionModel): Model = {
       TreeSerializer[Node](context.file("node"), withImpurities = true).write(obj.root)
       model
     }
 
-    override def load(context: BundleContext, model: ReadableModel): DecisionTreeRegressionModel = {
+    override def load(context: BundleContext, model: Model): DecisionTreeRegressionModel = {
       val root = TreeSerializer[Node](context.file("node"), withImpurities = true).read()
       DecisionTreeRegressionModel(root)
     }
@@ -100,7 +101,7 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegression, DecisionT
 
   override def model(node: DecisionTreeRegression): DecisionTreeRegressionModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: DecisionTreeRegressionModel): DecisionTreeRegression = {
+  override def load(context: BundleContext, node: dsl.Node, model: DecisionTreeRegressionModel): DecisionTreeRegression = {
     DecisionTreeRegression(uid = node.name,
       input = node.shape.standardInput.name,
       output = node.shape.standardOutput.name,

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/LinearRegressionOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/LinearRegressionOp.scala
@@ -2,7 +2,8 @@ package ml.combust.bundle.test_ops
 
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.BundleContext
-import ml.combust.bundle.dsl.{Bundle, _}
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.dsl
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -18,12 +19,12 @@ object LinearRegressionOp extends OpNode[LinearRegression, LinearModel] {
   override val Model: OpModel[LinearModel] = new OpModel[LinearModel] {
     override def opName: String = Bundle.BuiltinOps.regression.linear_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: LinearModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: LinearModel): Model = {
       model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients))).
         withAttr(Attribute("intercept", Value.double(obj.intercept)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): LinearModel = {
+    override def load(context: BundleContext, model: Model): LinearModel = {
       LinearModel(coefficients = model.value("coefficients").getDoubleVector,
         intercept = model.value("intercept").getDouble)
     }
@@ -33,7 +34,7 @@ object LinearRegressionOp extends OpNode[LinearRegression, LinearModel] {
 
   override def model(node: LinearRegression): LinearModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: LinearModel): LinearRegression = {
+  override def load(context: BundleContext, node: dsl.Node, model: LinearModel): LinearRegression = {
     LinearRegression(uid = node.name,
       input = node.shape.standardInput.name,
       output = node.shape.standardOutput.name,

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/PipelineOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/PipelineOp.scala
@@ -2,7 +2,8 @@ package ml.combust.bundle.test_ops
 
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.{BundleContext, GraphSerializer}
-import ml.combust.bundle.dsl.{Bundle, _}
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.dsl
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -14,11 +15,11 @@ object PipelineOp extends OpNode[Pipeline, PipelineModel] {
   override val Model: OpModel[PipelineModel] = new OpModel[PipelineModel] {
     override def opName: String = Bundle.BuiltinOps.pipeline
 
-    override def store(context: BundleContext, model: WritableModel, obj: PipelineModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: PipelineModel): Model = {
       model.withAttr(Attribute("nodes", Value.stringList(GraphSerializer(context).write(obj.stages))))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): PipelineModel = {
+    override def load(context: BundleContext, model: Model): PipelineModel = {
       PipelineModel(GraphSerializer(context).read(model.value("nodes").getStringList).
         map(_.asInstanceOf[Transformer]))
     }
@@ -28,7 +29,7 @@ object PipelineOp extends OpNode[Pipeline, PipelineModel] {
 
   override def model(node: Pipeline): PipelineModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: PipelineModel): Pipeline = {
+  override def load(context: BundleContext, node: dsl.Node, model: PipelineModel): Pipeline = {
     Pipeline(node.name, model)
   }
 

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/StringIndexerOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/StringIndexerOp.scala
@@ -2,7 +2,8 @@ package ml.combust.bundle.test_ops
 
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.BundleContext
-import ml.combust.bundle.dsl.{Bundle, _}
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.dsl
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -17,11 +18,11 @@ object StringIndexerOp extends OpNode[StringIndexer, StringIndexerModel] {
   override val Model: OpModel[StringIndexerModel] = new OpModel[StringIndexerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.string_indexer
 
-    override def store(context: BundleContext, model: WritableModel, obj: StringIndexerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: StringIndexerModel): Model = {
       model.withAttr(Attribute("labels", Value.stringList(obj.strings)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): StringIndexerModel = {
+    override def load(context: BundleContext, model: Model): StringIndexerModel = {
       StringIndexerModel(strings = model.value("labels").getStringList)
     }
   }
@@ -30,7 +31,7 @@ object StringIndexerOp extends OpNode[StringIndexer, StringIndexerModel] {
 
   override def model(node: StringIndexer): StringIndexerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: StringIndexerModel): StringIndexer = {
+  override def load(context: BundleContext, node: dsl.Node, model: StringIndexerModel): StringIndexer = {
     StringIndexer(uid = node.name,
       input = node.shape.standardInput.name,
       output = node.shape.standardOutput.name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/PipelineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/PipelineOp.scala
@@ -12,12 +12,12 @@ object PipelineOp extends OpNode[Pipeline, Pipeline] {
   override val Model: OpModel[Pipeline] = new OpModel[Pipeline] {
     override def opName: String = Bundle.BuiltinOps.pipeline
 
-    override def store(context: BundleContext, model: WritableModel, obj: Pipeline): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: Pipeline): Model = {
       val nodes = GraphSerializer(context).write(obj.transformers)
       model.withAttr(Attribute("nodes", Value.stringList(nodes)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): Pipeline = {
+    override def load(context: BundleContext, model: Model): Pipeline = {
       val nodes = GraphSerializer(context).read(model.value("nodes").getStringList).map(_.asInstanceOf[Transformer])
       Pipeline(transformers = nodes)
     }
@@ -27,7 +27,7 @@ object PipelineOp extends OpNode[Pipeline, Pipeline] {
 
   override def model(node: Pipeline): Pipeline = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: Pipeline): Pipeline = {
+  override def load(context: BundleContext, node: Node, model: Pipeline): Pipeline = {
     model.copy(uid = node.name)
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -1,7 +1,7 @@
 package ml.combust.mleap.runtime.serialization.bundle.ops.classification
 
 import ml.combust.mleap.core.classification.DecisionTreeClassifierModel
-import ml.combust.mleap.core.tree.Node
+import ml.combust.mleap.core.tree
 import ml.combust.mleap.runtime.serialization.bundle.tree.MleapNodeWrapper
 import ml.combust.mleap.runtime.transformer.classification.DecisionTreeClassifier
 import ml.combust.bundle.op.{OpModel, OpNode}
@@ -18,14 +18,14 @@ object DecisionTreeClassifierOp extends OpNode[DecisionTreeClassifier, DecisionT
   override val Model: OpModel[DecisionTreeClassifierModel] = new OpModel[DecisionTreeClassifierModel] {
     override def opName: String = Bundle.BuiltinOps.classification.decision_tree_classifier
 
-    override def store(context: BundleContext, model: WritableModel, obj: DecisionTreeClassifierModel): WritableModel = {
-      TreeSerializer[Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
+    override def store(context: BundleContext, model: Model, obj: DecisionTreeClassifierModel): Model = {
+      TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
       model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
         withAttr(Attribute("num_classes", Value.long(obj.numClasses)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): DecisionTreeClassifierModel = {
-      val rootNode = TreeSerializer[Node](context.file("nodes"), withImpurities = true).read()
+    override def load(context: BundleContext, model: Model): DecisionTreeClassifierModel = {
+      val rootNode = TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).read()
       DecisionTreeClassifierModel(rootNode,
         numClasses = model.value("num_classes").getLong.toInt,
         numFeatures = model.value("num_features").getLong.toInt)
@@ -36,7 +36,7 @@ object DecisionTreeClassifierOp extends OpNode[DecisionTreeClassifier, DecisionT
 
   override def model(node: DecisionTreeClassifier): DecisionTreeClassifierModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: DecisionTreeClassifierModel): DecisionTreeClassifier = {
+  override def load(context: BundleContext, node: Node, model: DecisionTreeClassifierModel): DecisionTreeClassifier = {
     DecisionTreeClassifier(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/GBTClassifierOp.scala
@@ -14,7 +14,7 @@ object GBTClassifierOp extends OpNode[GBTClassifier, GBTClassifierModel] {
   override val Model: OpModel[GBTClassifierModel] = new OpModel[GBTClassifierModel] {
     override def opName: String = Bundle.BuiltinOps.classification.gbt_classifier
 
-    override def store(context: BundleContext, model: WritableModel, obj: GBTClassifierModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: GBTClassifierModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -32,7 +32,7 @@ object GBTClassifierOp extends OpNode[GBTClassifier, GBTClassifierModel] {
         getOrElse(m)
     }
 
-    override def load(context: BundleContext, model: ReadableModel): GBTClassifierModel = {
+    override def load(context: BundleContext, model: Model): GBTClassifierModel = {
       if(model.value("num_classes").getLong != 2) {
         throw new Error("MLeap only supports binary logistic regression")
       } // TODO: Better error
@@ -56,18 +56,13 @@ object GBTClassifierOp extends OpNode[GBTClassifier, GBTClassifierModel] {
 
   override def model(node: GBTClassifier): GBTClassifierModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: GBTClassifierModel): GBTClassifier = {
+  override def load(context: BundleContext, node: Node, model: GBTClassifierModel): GBTClassifier = {
     GBTClassifier(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,
       model = model)
   }
 
-  override def shape(node: GBTClassifier): Shape = {
-    val shape = Shape().withInput(node.featuresCol, "features").
-      withOutput(node.predictionCol, "prediction")
-    node.probabilityCol.
-      map(p => shape.withOutput(p, "probability")).
-      getOrElse(shape)
-  }
+  override def shape(node: GBTClassifier): Shape = Shape().withInput(node.featuresCol, "features").
+    withOutput(node.predictionCol, "prediction")
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/OneVsRestOp.scala
@@ -13,7 +13,7 @@ object OneVsRestOp extends OpNode[OneVsRest, OneVsRestModel] {
   override val Model: OpModel[OneVsRestModel] = new OpModel[OneVsRestModel] {
     override def opName: String = Bundle.BuiltinOps.classification.one_vs_rest
 
-    override def store(context: BundleContext, model: WritableModel, obj: OneVsRestModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: OneVsRestModel): Model = {
       var i = 0
       for(cModel <- obj.classifiers) {
         val name = s"model$i"
@@ -25,7 +25,7 @@ object OneVsRestOp extends OpNode[OneVsRest, OneVsRestModel] {
       model.withAttr(Attribute("num_classes", Value.long(obj.classifiers.length)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): OneVsRestModel = {
+    override def load(context: BundleContext, model: Model): OneVsRestModel = {
       val numClasses = model.value("num_classes").getLong.toInt
 
       val models = (0 until numClasses).toArray.map {
@@ -40,7 +40,7 @@ object OneVsRestOp extends OpNode[OneVsRest, OneVsRestModel] {
 
   override def model(node: OneVsRest): OneVsRestModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: OneVsRestModel): OneVsRest = {
+  override def load(context: BundleContext, node: Node, model: OneVsRestModel): OneVsRest = {
     OneVsRest(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,
@@ -48,11 +48,7 @@ object OneVsRestOp extends OpNode[OneVsRest, OneVsRestModel] {
       model = model)
   }
 
-  override def shape(node: OneVsRest): Shape = {
-    val s = Shape().withInput(node.featuresCol, "features").
-      withOutput(node.predictionCol, "prediction")
-    node.probabilityCol.map {
-      pc => s.withOutput(pc, "probability")
-    }.getOrElse(s)
-  }
+  override def shape(node: OneVsRest): Shape = Shape().withInput(node.featuresCol, "features").
+    withOutput(node.predictionCol, "prediction").
+    withOutput(node.probabilityCol, "probability"  )
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -16,7 +16,7 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassifier, RandomFor
   override val Model: OpModel[RandomForestClassifierModel] = new OpModel[RandomForestClassifierModel] {
     override def opName: String = Bundle.BuiltinOps.classification.random_forest_classifier
 
-    override def store(context: BundleContext, model: WritableModel, obj: RandomForestClassifierModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: RandomForestClassifierModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -31,7 +31,7 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassifier, RandomFor
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): RandomForestClassifierModel = {
+    override def load(context: BundleContext, model: Model): RandomForestClassifierModel = {
       val numFeatures = model.value("num_features").getLong.toInt
       val numClasses = model.value("num_classes").getLong.toInt
       val treeWeights = model.value("tree_weights").getDoubleList
@@ -51,7 +51,7 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassifier, RandomFor
 
   override def model(node: RandomForestClassifier): RandomForestClassifierModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: RandomForestClassifierModel): RandomForestClassifier = {
+  override def load(context: BundleContext, node: Node, model: RandomForestClassifierModel): RandomForestClassifier = {
     RandomForestClassifier(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.input("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/classification/SupportVectorMachineOp.scala
@@ -14,16 +14,14 @@ object SupportVectorMachineOp extends OpNode[SupportVectorMachine, SupportVector
   override val Model: OpModel[SupportVectorMachineModel] = new OpModel[SupportVectorMachineModel] {
     override def opName: String = Bundle.BuiltinOps.classification.support_vector_machine
 
-    override def store(context: BundleContext, model: WritableModel, obj: SupportVectorMachineModel): WritableModel = {
-      val m = model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
+    override def store(context: BundleContext, model: Model, obj: SupportVectorMachineModel): Model = {
+      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
         withAttr(Attribute("intercept", Value.double(obj.intercept))).
-        withAttr(Attribute("num_classes", Value.long(2)))
-      obj.threshold.
-        map(t => m.withAttr(Attribute("threshold", Value.double(t)))).
-        getOrElse(m)
+        withAttr(Attribute("num_classes", Value.long(2))).
+        withAttr(obj.threshold.map(t => Attribute("threshold", Value.double(t))))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): SupportVectorMachineModel = {
+    override def load(context: BundleContext, model: Model): SupportVectorMachineModel = {
       if(model.value("num_classes").getLong != 2) {
         throw new Error("MLeap only supports binary SVM")
       } // TODO: Better error
@@ -37,7 +35,7 @@ object SupportVectorMachineOp extends OpNode[SupportVectorMachine, SupportVector
 
   override def model(node: SupportVectorMachine): SupportVectorMachineModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: SupportVectorMachineModel): SupportVectorMachine = {
+  override def load(context: BundleContext, node: Node, model: SupportVectorMachineModel): SupportVectorMachine = {
     SupportVectorMachine(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/BucketizerOp.scala
@@ -13,21 +13,20 @@ object BucketizerOp extends OpNode[Bucketizer, BucketizerModel]{
   override val Model: OpModel[BucketizerModel] = new OpModel[BucketizerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.bucketizer
 
-    override def store(context: BundleContext, model: WritableModel, obj: BucketizerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: BucketizerModel): Model = {
       model.withAttr(Attribute("splits", Value.doubleList(obj.splits)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): BucketizerModel = {
+    override def load(context: BundleContext, model: Model): BucketizerModel = {
       BucketizerModel(splits = model.value("splits").getDoubleList.toArray)
     }
-
   }
 
   override def name(node: Bucketizer): String = node.uid
 
   override def model(node: Bucketizer): BucketizerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: BucketizerModel): Bucketizer = {
+  override def load(context: BundleContext, node: Node, model: BucketizerModel): Bucketizer = {
     Bucketizer(inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,
       model = model)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/ElementwiseProductOp.scala
@@ -14,21 +14,20 @@ object ElementwiseProductOp extends OpNode[ElementwiseProduct, ElementwiseProduc
   override val Model: OpModel[ElementwiseProductModel] = new OpModel[ElementwiseProductModel] {
     override def opName: String = Bundle.BuiltinOps.feature.elementwise_product
 
-    override def store(context: BundleContext, model: WritableModel, obj: ElementwiseProductModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: ElementwiseProductModel): Model = {
       model.withAttr(Attribute("scalingVec", Value.doubleVector(obj.scalingVec.toArray)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): ElementwiseProductModel = {
+    override def load(context: BundleContext, model: Model): ElementwiseProductModel = {
       ElementwiseProductModel(scalingVec = Vectors.dense(model.value("scalingVec").getDoubleVector.toArray))
     }
-
   }
 
   override def name(node: ElementwiseProduct): String = node.uid
 
   override def model(node: ElementwiseProduct): ElementwiseProductModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: ElementwiseProductModel): ElementwiseProduct = {
+  override def load(context: BundleContext, node: Node, model: ElementwiseProductModel): ElementwiseProduct = {
     ElementwiseProduct(inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,
       model = model

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -14,21 +14,20 @@ object MaxAbsScalerOp extends OpNode[MaxAbsScaler, MaxAbsScalerModel]{
   override val Model: OpModel[MaxAbsScalerModel] = new OpModel[MaxAbsScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.max_abs_scaler
 
-    override def store(context: BundleContext, model: WritableModel, obj: MaxAbsScalerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: MaxAbsScalerModel): Model = {
       model.withAttr(Attribute("maxAbs", Value.doubleVector(obj.maxAbs.toArray)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): MaxAbsScalerModel = {
+    override def load(context: BundleContext, model: Model): MaxAbsScalerModel = {
       MaxAbsScalerModel(maxAbs = Vectors.dense(model.value("maxAbs").getDoubleVector.toArray))
     }
-
   }
 
   override def name(node: MaxAbsScaler): String = node.uid
 
   override def model(node: MaxAbsScaler): MaxAbsScalerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: MaxAbsScalerModel): MaxAbsScaler = {
+  override def load(context: BundleContext, node: Node, model: MaxAbsScalerModel): MaxAbsScaler = {
     MaxAbsScaler(inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,
       model = model)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/MinMaxScalerOp.scala
@@ -14,12 +14,12 @@ object MinMaxScalerOp extends OpNode[MinMaxScaler, MinMaxScalerModel]{
   override val Model: OpModel[MinMaxScalerModel] = new OpModel[MinMaxScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.min_max_scaler
 
-    override def store(context: BundleContext, model: WritableModel, obj: MinMaxScalerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: MinMaxScalerModel): Model = {
       model.withAttr(Attribute("min", Value.doubleVector(obj.originalMin.toArray))).
         withAttr(Attribute("max", Value.doubleVector(obj.originalMax.toArray)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): MinMaxScalerModel = {
+    override def load(context: BundleContext, model: Model): MinMaxScalerModel = {
       MinMaxScalerModel(originalMin = Vectors.dense(model.value("min").getDoubleVector.toArray),
         originalMax = Vectors.dense(model.value("max").getDoubleVector.toArray))
     }
@@ -29,7 +29,7 @@ object MinMaxScalerOp extends OpNode[MinMaxScaler, MinMaxScalerModel]{
 
   override def model(node: MinMaxScaler): MinMaxScalerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: MinMaxScalerModel): MinMaxScaler = {
+  override def load(context: BundleContext, node: Node, model: MinMaxScalerModel): MinMaxScaler = {
     MinMaxScaler(inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,
       model = model)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/NormalizerOp.scala
@@ -13,11 +13,11 @@ object NormalizerOp extends OpNode[Normalizer, NormalizerModel] {
   override val Model: OpModel[NormalizerModel] = new OpModel[NormalizerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.normalizer
 
-    override def store(context: BundleContext, model: WritableModel, obj: NormalizerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: NormalizerModel): Model = {
       model.withAttr(Attribute("p_norm", Value.double(obj.pNorm)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): NormalizerModel = {
+    override def load(context: BundleContext, model: Model): NormalizerModel = {
       NormalizerModel(pNorm = model.value("p_norm").getDouble)
     }
   }
@@ -26,7 +26,7 @@ object NormalizerOp extends OpNode[Normalizer, NormalizerModel] {
 
   override def model(node: Normalizer): NormalizerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: NormalizerModel): Normalizer = {
+  override def load(context: BundleContext, node: Node, model: NormalizerModel): Normalizer = {
     Normalizer(uid = node.name,
       inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -13,11 +13,11 @@ object ReverseStringIndexerOp extends OpNode[ReverseStringIndexer, ReverseString
   override val Model: OpModel[ReverseStringIndexerModel] = new OpModel[ReverseStringIndexerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.reverse_string_indexer
 
-    override def store(context: BundleContext, model: WritableModel, obj: ReverseStringIndexerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: ReverseStringIndexerModel): Model = {
       model.withAttr(Attribute("labels", Value.stringList(obj.labels)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): ReverseStringIndexerModel = {
+    override def load(context: BundleContext, model: Model): ReverseStringIndexerModel = {
       ReverseStringIndexerModel(labels = model.value("labels").getStringList)
     }
   }
@@ -26,7 +26,7 @@ object ReverseStringIndexerOp extends OpNode[ReverseStringIndexer, ReverseString
 
   override def model(node: ReverseStringIndexer): ReverseStringIndexerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: ReverseStringIndexerModel): ReverseStringIndexer = {
+  override def load(context: BundleContext, node: Node, model: ReverseStringIndexerModel): ReverseStringIndexer = {
     ReverseStringIndexer(inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,
       model = model)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/StandardScalerOp.scala
@@ -14,20 +14,12 @@ object StandardScalerOp extends OpNode[StandardScaler, StandardScalerModel] {
   override val Model: OpModel[StandardScalerModel] = new OpModel[StandardScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.standard_scaler
 
-    override def store(context: BundleContext, model: WritableModel, obj: StandardScalerModel): WritableModel = {
-      var model2 = model
-      model2 = obj.mean match {
-        case Some(mean) => model2.withAttr(Attribute("mean", Value.doubleVector(mean.toArray)))
-        case None => model2
-      }
-      model2 = obj.std match {
-        case Some(std) => model2.withAttr(Attribute("std", Value.doubleVector(std.toArray)))
-        case None => model2
-      }
-      model2
+    override def store(context: BundleContext, model: Model, obj: StandardScalerModel): Model = {
+      model.withAttr(obj.mean.map(m => Attribute("mean", Value.doubleVector(m.toArray)))).
+        withAttr(obj.std.map(s => Attribute("std", Value.doubleVector(s.toArray))))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): StandardScalerModel = {
+    override def load(context: BundleContext, model: Model): StandardScalerModel = {
       val mean = model.getValue("mean").map(_.getDoubleVector.toArray).map(Vectors.dense)
       val std = model.getValue("std").map(_.getDoubleVector.toArray).map(Vectors.dense)
       StandardScalerModel(mean = mean, std = std)
@@ -38,7 +30,7 @@ object StandardScalerOp extends OpNode[StandardScaler, StandardScalerModel] {
 
   override def model(node: StandardScaler): StandardScalerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: StandardScalerModel): StandardScaler = {
+  override def load(context: BundleContext, node: Node, model: StandardScalerModel): StandardScaler = {
     StandardScaler(uid = node.name,
       inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/StringIndexerOp.scala
@@ -13,11 +13,11 @@ object StringIndexerOp extends OpNode[StringIndexer, StringIndexerModel] {
   override val Model: OpModel[StringIndexerModel] = new OpModel[StringIndexerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.string_indexer
 
-    override def store(context: BundleContext, model: WritableModel, obj: StringIndexerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: StringIndexerModel): Model = {
       model.withAttr(Attribute("labels", Value.stringList(obj.labels)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): StringIndexerModel = {
+    override def load(context: BundleContext, model: Model): StringIndexerModel = {
       StringIndexerModel(labels = model.value("labels").getStringList)
     }
   }
@@ -26,7 +26,7 @@ object StringIndexerOp extends OpNode[StringIndexer, StringIndexerModel] {
 
   override def model(node: StringIndexer): StringIndexerModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: StringIndexerModel): StringIndexer = {
+  override def load(context: BundleContext, node: Node, model: StringIndexerModel): StringIndexer = {
     StringIndexer(inputCol = node.shape.standardInput.name,
       outputCol = node.shape.standardOutput.name,
       model = model)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/VectorAssemblerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/feature/VectorAssemblerOp.scala
@@ -13,16 +13,16 @@ object VectorAssemblerOp extends OpNode[VectorAssembler, VectorAssemblerModel] {
   override val Model: OpModel[VectorAssemblerModel] = new OpModel[VectorAssemblerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.vector_assembler
 
-    override def store(context: BundleContext, model: WritableModel, obj: VectorAssemblerModel): WritableModel = { model }
+    override def store(context: BundleContext, model: Model, obj: VectorAssemblerModel): Model = { model }
 
-    override def load(context: BundleContext, model: ReadableModel): VectorAssemblerModel = VectorAssemblerModel.default
+    override def load(context: BundleContext, model: Model): VectorAssemblerModel = VectorAssemblerModel.default
   }
 
   override def name(node: VectorAssembler): String = node.uid
 
   override def model(node: VectorAssembler): VectorAssemblerModel = VectorAssemblerModel.default
 
-  override def load(context: BundleContext, node: ReadableNode, model: VectorAssemblerModel): VectorAssembler = {
+  override def load(context: BundleContext, node: Node, model: VectorAssemblerModel): VectorAssembler = {
     VectorAssembler(uid = node.name,
       inputCols = node.shape.inputs.map(_.name).toArray,
       outputCol = node.shape.standardOutput.name)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -1,7 +1,7 @@
 package ml.combust.mleap.runtime.serialization.bundle.ops.regression
 
 import ml.combust.mleap.core.regression.DecisionTreeRegressionModel
-import ml.combust.mleap.core.tree.Node
+import ml.combust.mleap.core.tree
 import ml.combust.mleap.runtime.serialization.bundle.tree.MleapNodeWrapper
 import ml.combust.mleap.runtime.transformer.regression.DecisionTreeRegression
 import ml.combust.bundle.op.{OpModel, OpNode}
@@ -18,13 +18,13 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegression, DecisionT
   override val Model: OpModel[DecisionTreeRegressionModel] = new OpModel[DecisionTreeRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.decision_tree_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: DecisionTreeRegressionModel): WritableModel = {
-      TreeSerializer[Node](context.file("nodes"), withImpurities = false).write(obj.rootNode)
+    override def store(context: BundleContext, model: Model, obj: DecisionTreeRegressionModel): Model = {
+      TreeSerializer[tree.Node](context.file("nodes"), withImpurities = false).write(obj.rootNode)
       model.withAttr(Attribute("num_features", Value.long(obj.numFeatures)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): DecisionTreeRegressionModel = {
-      val rootNode = TreeSerializer[Node](context.file("nodes"), withImpurities = false).read()
+    override def load(context: BundleContext, model: Model): DecisionTreeRegressionModel = {
+      val rootNode = TreeSerializer[tree.Node](context.file("nodes"), withImpurities = false).read()
       DecisionTreeRegressionModel(rootNode, numFeatures = model.value("num_features").getLong.toInt)
     }
   }
@@ -33,7 +33,7 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegression, DecisionT
 
   override def model(node: DecisionTreeRegression): DecisionTreeRegressionModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: DecisionTreeRegressionModel): DecisionTreeRegression = {
+  override def load(context: BundleContext, node: Node, model: DecisionTreeRegressionModel): DecisionTreeRegression = {
     DecisionTreeRegression(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/GBTRegressionOp.scala
@@ -13,7 +13,7 @@ object GBTRegressionOp extends OpNode[GBTRegression, GBTRegressionModel] {
   override val Model: OpModel[GBTRegressionModel] = new OpModel[GBTRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.gbt_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: GBTRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: GBTRegressionModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -27,7 +27,7 @@ object GBTRegressionOp extends OpNode[GBTRegression, GBTRegressionModel] {
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): GBTRegressionModel = {
+    override def load(context: BundleContext, model: Model): GBTRegressionModel = {
       val numFeatures = model.value("num_features").getLong.toInt
       val treeWeights = model.value("tree_weights").getDoubleList
 
@@ -45,7 +45,7 @@ object GBTRegressionOp extends OpNode[GBTRegression, GBTRegressionModel] {
 
   override def model(node: GBTRegression): GBTRegressionModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: GBTRegressionModel): GBTRegression = {
+  override def load(context: BundleContext, node: Node, model: GBTRegressionModel): GBTRegression = {
     GBTRegression(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/LinearRegressionOp.scala
@@ -14,12 +14,12 @@ object LinearRegressionOp extends OpNode[LinearRegression, LinearRegressionModel
   override val Model: OpModel[LinearRegressionModel] = new OpModel[LinearRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.linear_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: LinearRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: LinearRegressionModel): Model = {
       model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
         withAttr(Attribute("intercept", Value.double(obj.intercept)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): LinearRegressionModel = {
+    override def load(context: BundleContext, model: Model): LinearRegressionModel = {
       LinearRegressionModel(coefficients = Vectors.dense(model.value("coefficients").getDoubleVector.toArray),
         intercept = model.value("intercept").getDouble)
     }
@@ -29,7 +29,7 @@ object LinearRegressionOp extends OpNode[LinearRegression, LinearRegressionModel
 
   override def model(node: LinearRegression): LinearRegressionModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: LinearRegressionModel): LinearRegression = {
+  override def load(context: BundleContext, node: Node, model: LinearRegressionModel): LinearRegression = {
     LinearRegression(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.output("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/serialization/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -16,7 +16,7 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegression, RandomFor
   override val Model: OpModel[RandomForestRegressionModel] = new OpModel[RandomForestRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.random_forest_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: RandomForestRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: RandomForestRegressionModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -30,7 +30,7 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegression, RandomFor
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): RandomForestRegressionModel = {
+    override def load(context: BundleContext, model: Model): RandomForestRegressionModel = {
       val numFeatures = model.value("num_features").getLong.toInt
       val treeWeights = model.value("tree_weights").getDoubleList
 
@@ -48,7 +48,7 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegression, RandomFor
 
   override def model(node: RandomForestRegression): RandomForestRegressionModel = node.model
 
-  override def load(context: BundleContext, node: ReadableNode, model: RandomForestRegressionModel): RandomForestRegression = {
+  override def load(context: BundleContext, node: Node, model: RandomForestRegressionModel): RandomForestRegression = {
     RandomForestRegression(uid = node.name,
       featuresCol = node.shape.input("features").name,
       predictionCol = node.shape.input("prediction").name,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
@@ -14,22 +14,11 @@ import scala.util.Try
 case class GBTClassifier(override val uid: String = Transformer.uniqueName("gbt_classifier"),
                          featuresCol: String,
                          predictionCol: String,
-                         probabilityCol: Option[String] = None,
                          model: GBTClassifierModel) extends Transformer {
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
     builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
       case(b, featuresIndex) =>
-        probabilityCol match {
-          case Some(probability) =>
-            b.withOutputs(Seq(StructField(predictionCol, DoubleType),
-              StructField(probability, DoubleType))) {
-              row =>
-                val (prediction, probability) = model.predictWithProbability(row.getVector(featuresIndex))
-                Row(prediction, probability)
-            }
-          case None =>
-            b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-        }
+        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifierSpec.scala
@@ -29,19 +29,6 @@ class GBTClassifierSpec extends FunSpec {
       assert(prediction == (0.5 * 0.5 + 0.75 * 2.0 + 0.1 * 1.0))
     }
 
-    describe("with probability column") {
-      val gbt2 = gbt.copy(probabilityCol = Some("probability"),
-        model = gbt.model.copy(threshold = Some(0.0)))
-
-      it("uses the GBT to output prediction class and probability") {
-        val frame2 = gbt2.transform(frame).get
-        val row = frame2.dataset.toArray(0)
-
-        assert(row.getDouble(1) == 1.0)
-        assert(row.getDouble(2) == (0.5 * 0.5 + 0.75 * 2.0 + 0.1 * 1.0))
-      }
-    }
-
     describe("with invalid features column") {
       val gbt2 = gbt.copy(featuresCol = "bad_features")
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
@@ -12,12 +12,12 @@ object PipelineOp extends OpNode[PipelineModel, PipelineModel] {
   override val Model: OpModel[PipelineModel] = new OpModel[PipelineModel] {
     override def opName: String = Bundle.BuiltinOps.pipeline
 
-    override def store(context: BundleContext, model: WritableModel, obj: PipelineModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: PipelineModel): Model = {
       val nodes = GraphSerializer(context).write(obj.stages)
       model.withAttr(Attribute("nodes", Value.stringList(nodes)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): PipelineModel = {
+    override def load(context: BundleContext, model: Model): PipelineModel = {
       val nodes = GraphSerializer(context).read(model.value("nodes").getStringList).map(_.asInstanceOf[Transformer]).toArray
       new PipelineModel(uid = "", stages = nodes)
     }
@@ -27,7 +27,7 @@ object PipelineOp extends OpNode[PipelineModel, PipelineModel] {
 
   override def model(node: PipelineModel): PipelineModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: PipelineModel): PipelineModel = {
+  override def load(context: BundleContext, node: Node, model: PipelineModel): PipelineModel = {
     new PipelineModel(uid = node.name, stages = model.stages)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -3,6 +3,7 @@ package org.apache.spark.ml.bundle.ops.classification
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.BundleContext
 import ml.combust.bundle.tree.TreeSerializer
+import org.apache.spark.ml.tree
 import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.tree.SparkNodeWrapper
 import org.apache.spark.ml.classification.DecisionTreeClassificationModel
@@ -16,14 +17,14 @@ object DecisionTreeClassifierOp extends OpNode[DecisionTreeClassificationModel, 
   override val Model: OpModel[DecisionTreeClassificationModel] = new OpModel[DecisionTreeClassificationModel] {
     override def opName: String = Bundle.BuiltinOps.classification.decision_tree_classifier
 
-    override def store(context: BundleContext, model: WritableModel, obj: DecisionTreeClassificationModel): WritableModel = {
-      TreeSerializer[org.apache.spark.ml.tree.Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
+    override def store(context: BundleContext, model: Model, obj: DecisionTreeClassificationModel): Model = {
+      TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
       model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
         withAttr(Attribute("num_classes", Value.long(obj.numClasses)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): DecisionTreeClassificationModel = {
-      val rootNode = TreeSerializer[org.apache.spark.ml.tree.Node](context.file("nodes"), withImpurities = true).read()
+    override def load(context: BundleContext, model: Model): DecisionTreeClassificationModel = {
+      val rootNode = TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).read()
       new DecisionTreeClassificationModel(uid = "",
         rootNode = rootNode,
         numClasses = model.value("num_classes").getLong.toInt,
@@ -35,7 +36,7 @@ object DecisionTreeClassifierOp extends OpNode[DecisionTreeClassificationModel, 
 
   override def model(node: DecisionTreeClassificationModel): DecisionTreeClassificationModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: DecisionTreeClassificationModel): DecisionTreeClassificationModel = {
+  override def load(context: BundleContext, node: Node, model: DecisionTreeClassificationModel): DecisionTreeClassificationModel = {
     new DecisionTreeClassificationModel(uid = node.name,
       rootNode = model.rootNode,
       numClasses = model.numClasses,

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
@@ -13,7 +13,7 @@ object GBTClassifierOp extends OpNode[GBTClassificationModel, GBTClassificationM
   override val Model: OpModel[GBTClassificationModel] = new OpModel[GBTClassificationModel] {
     override def opName: String = Bundle.BuiltinOps.classification.gbt_classifier
 
-    override def store(context: BundleContext, model: WritableModel, obj: GBTClassificationModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: GBTClassificationModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -28,7 +28,7 @@ object GBTClassifierOp extends OpNode[GBTClassificationModel, GBTClassificationM
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): GBTClassificationModel = {
+    override def load(context: BundleContext, model: Model): GBTClassificationModel = {
       if(model.value("num_classes").getLong != 2) {
         throw new Error("MLeap only supports binary logistic regression")
       } // TODO: Better error
@@ -51,7 +51,7 @@ object GBTClassifierOp extends OpNode[GBTClassificationModel, GBTClassificationM
 
   override def model(node: GBTClassificationModel): GBTClassificationModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: GBTClassificationModel): GBTClassificationModel = {
+  override def load(context: BundleContext, node: Node, model: GBTClassificationModel): GBTClassificationModel = {
     new GBTClassificationModel(uid = node.name,
       _trees = model.trees,
       _treeWeights = model.treeWeights,

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOp.scala
@@ -13,16 +13,14 @@ object LogisticRegressionOp extends OpNode[LogisticRegressionModel, LogisticRegr
   override val Model: OpModel[LogisticRegressionModel] = new OpModel[LogisticRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.classification.logistic_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: LogisticRegressionModel): WritableModel = {
-      val m = model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
+    override def store(context: BundleContext, model: Model, obj: LogisticRegressionModel): Model = {
+      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
         withAttr(Attribute("intercept", Value.double(obj.intercept))).
-        withAttr(Attribute("num_classes", Value.long(obj.numClasses)))
-
-      obj.get(obj.threshold).map(t => m.withAttr(Attribute("threshold", Value.double(t)))).
-        getOrElse(m)
+        withAttr(Attribute("num_classes", Value.long(obj.numClasses))).
+        withAttr(obj.get(obj.threshold).map(t => Attribute("threshold", Value.double(t))))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): LogisticRegressionModel = {
+    override def load(context: BundleContext, model: Model): LogisticRegressionModel = {
       // TODO: better error
       if(model.value("num_classes").getLong != 2) {
         throw new Error("Only binary logistic regression supported in Spark")
@@ -42,7 +40,7 @@ object LogisticRegressionOp extends OpNode[LogisticRegressionModel, LogisticRegr
 
   override def model(node: LogisticRegressionModel): LogisticRegressionModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: LogisticRegressionModel): LogisticRegressionModel = {
+  override def load(context: BundleContext, node: Node, model: LogisticRegressionModel): LogisticRegressionModel = {
     val lr = new LogisticRegressionModel(uid = node.name,
       coefficients = model.coefficients,
       intercept = model.intercept).copy(model.extractParamMap).

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
@@ -14,7 +14,7 @@ object OneVsRestOp extends OpNode[OneVsRestModel, OneVsRestModel] {
   override val Model: OpModel[OneVsRestModel] = new OpModel[OneVsRestModel] {
     override def opName: String = Bundle.BuiltinOps.classification.one_vs_rest
 
-    override def store(context: BundleContext, model: WritableModel, obj: OneVsRestModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: OneVsRestModel): Model = {
       var i = 0
       for(cModel <- obj.models) {
         val name = s"model$i"
@@ -26,7 +26,7 @@ object OneVsRestOp extends OpNode[OneVsRestModel, OneVsRestModel] {
       model.withAttr(Attribute("num_classes", Value.long(obj.models.length)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): OneVsRestModel = {
+    override def load(context: BundleContext, model: Model): OneVsRestModel = {
       val numClasses = model.value("num_classes").getLong.toInt
 
       val models = (0 until numClasses).toArray.map {
@@ -45,7 +45,7 @@ object OneVsRestOp extends OpNode[OneVsRestModel, OneVsRestModel] {
 
   override def model(node: OneVsRestModel): OneVsRestModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: OneVsRestModel): OneVsRestModel = {
+  override def load(context: BundleContext, node: Node, model: OneVsRestModel): OneVsRestModel = {
     val labelMetadata = NominalAttribute.defaultAttr.
       withName(node.shape.output("prediction").name).
       withNumValues(model.models.length).
@@ -57,12 +57,7 @@ object OneVsRestOp extends OpNode[OneVsRestModel, OneVsRestModel] {
     m
   }
 
-  override def shape(node: OneVsRestModel): Shape = {
-    val s = Shape().withInput(node.getFeaturesCol, "features").
-      withOutput(node.getPredictionCol, "prediction")
-
-    if(node.isDefined(node.probabilityCol)) {
-      s.withOutput(node.getProbabilityCol, "probability")
-    } else { s }
-  }
+  override def shape(node: OneVsRestModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
+    withOutput(node.getPredictionCol, "prediction").
+    withOutput(node.getProbabilityCol, "probability")
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -15,7 +15,7 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassificationModel, 
   override val Model: OpModel[RandomForestClassificationModel] = new OpModel[RandomForestClassificationModel] {
     override def opName: String = Bundle.BuiltinOps.regression.random_forest_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: RandomForestClassificationModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: RandomForestClassificationModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -29,7 +29,7 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassificationModel, 
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): RandomForestClassificationModel = {
+    override def load(context: BundleContext, model: Model): RandomForestClassificationModel = {
       val numFeatures = model.value("num_features").getLong.toInt
       val numClasses = model.value("num_classes").getLong.toInt
 
@@ -48,7 +48,7 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassificationModel, 
 
   override def model(node: RandomForestClassificationModel): RandomForestClassificationModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: RandomForestClassificationModel): RandomForestClassificationModel = {
+  override def load(context: BundleContext, node: Node, model: RandomForestClassificationModel): RandomForestClassificationModel = {
     new RandomForestClassificationModel(uid = node.name,
       numClasses = model.numClasses,
       numFeatures = model.numFeatures,

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -12,11 +12,11 @@ object BucketizerOp extends OpNode[Bucketizer, Bucketizer] {
   override val Model: OpModel[Bucketizer] = new OpModel[Bucketizer] {
     override def opName: String = Bundle.BuiltinOps.feature.bucketizer
 
-    override def store(context: BundleContext, model: WritableModel, obj: Bucketizer): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: Bucketizer): Model = {
       model.withAttr(Attribute("splits", Value.doubleList(obj.getSplits)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): Bucketizer = {
+    override def load(context: BundleContext, model: Model): Bucketizer = {
       new Bucketizer(uid = "").setSplits(model.value("splits").getDoubleList.toArray)
     }
   }
@@ -25,7 +25,7 @@ object BucketizerOp extends OpNode[Bucketizer, Bucketizer] {
 
   override def model(node: Bucketizer): Bucketizer = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: Bucketizer): Bucketizer = {
+  override def load(context: BundleContext, node: Node, model: Bucketizer): Bucketizer = {
     new Bucketizer(uid = node.name).copy(model.extractParamMap()).
       setInputCol(node.shape.standardInput.name).
       setOutputCol(node.shape.standardOutput.name)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
@@ -13,11 +13,11 @@ object ElementwiseProductOp extends OpNode[ElementwiseProduct, ElementwiseProduc
   override val Model: OpModel[ElementwiseProduct] = new OpModel[ElementwiseProduct] {
     override def opName: String = Bundle.BuiltinOps.feature.elementwise_product
 
-    override def store(context: BundleContext, model: WritableModel, obj: ElementwiseProduct): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: ElementwiseProduct): Model = {
       model.withAttr(Attribute("scaling_vec", Value.doubleVector(obj.getScalingVec.toArray)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): ElementwiseProduct = {
+    override def load(context: BundleContext, model: Model): ElementwiseProduct = {
       new ElementwiseProduct(uid = "").setScalingVec(Vectors.dense(model.value("scaling_vec").getDoubleVector.toArray))
     }
   }
@@ -27,7 +27,7 @@ object ElementwiseProductOp extends OpNode[ElementwiseProduct, ElementwiseProduc
   override def model(node: ElementwiseProduct): ElementwiseProduct = node
 
 
-  override def load(context: BundleContext, node: ReadableNode, model: ElementwiseProduct): ElementwiseProduct = {
+  override def load(context: BundleContext, node: Node, model: ElementwiseProduct): ElementwiseProduct = {
     new ElementwiseProduct(uid = node.name).copy(model.extractParamMap()).
       setInputCol(node.shape.standardInput.name).
       setOutputCol(node.shape.standardOutput.name)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
@@ -12,12 +12,12 @@ object HashingTermFrequencyOp extends OpNode[HashingTF, HashingTF] {
   override val Model: OpModel[HashingTF] = new OpModel[HashingTF] {
     override def opName: String = Bundle.BuiltinOps.feature.hashing_term_frequency
 
-    override def store(context: BundleContext, model: WritableModel, obj: HashingTF): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: HashingTF): Model = {
       model.withAttr(Attribute("num_features", Value.long(obj.getNumFeatures))).
         withAttr(Attribute("binary", Value.boolean(obj.getBinary)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): HashingTF = {
+    override def load(context: BundleContext, model: Model): HashingTF = {
       new HashingTF(uid = "").setNumFeatures(model.value("num_features").getLong.toInt).
         setBinary(model.value("binary").getBoolean)
     }
@@ -27,7 +27,7 @@ object HashingTermFrequencyOp extends OpNode[HashingTF, HashingTF] {
 
   override def model(node: HashingTF): HashingTF = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: HashingTF): HashingTF = {
+  override def load(context: BundleContext, node: Node, model: HashingTF): HashingTF = {
     new HashingTF(uid = node.name).setNumFeatures(model.getNumFeatures).
       setBinary(model.getBinary).
       setInputCol(node.shape.standardInput.name).

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -13,11 +13,11 @@ object MaxAbsScalerOp extends OpNode[MaxAbsScalerModel, MaxAbsScalerModel]{
   override val Model: OpModel[MaxAbsScalerModel] = new OpModel[MaxAbsScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.max_abs_scaler
 
-    override def store(context: BundleContext, model: WritableModel, obj: MaxAbsScalerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: MaxAbsScalerModel): Model = {
       model.withAttr(Attribute("maxAbs", Value.doubleVector(obj.maxAbs.toArray)))
   }
 
-    override def load(context: BundleContext, model: ReadableModel): MaxAbsScalerModel = {
+    override def load(context: BundleContext, model: Model): MaxAbsScalerModel = {
       new MaxAbsScalerModel(uid = "",
         maxAbs = Vectors.dense(model.value("maxAbs").getDoubleVector.toArray))
     }
@@ -29,7 +29,7 @@ object MaxAbsScalerOp extends OpNode[MaxAbsScalerModel, MaxAbsScalerModel]{
   override def model(node: MaxAbsScalerModel): MaxAbsScalerModel = node
 
 
-  override def load(context: BundleContext, node: ReadableNode, model: MaxAbsScalerModel): MaxAbsScalerModel = {
+  override def load(context: BundleContext, node: Node, model: MaxAbsScalerModel): MaxAbsScalerModel = {
     new MaxAbsScalerModel(uid = node.name, maxAbs = model.maxAbs)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
@@ -13,12 +13,12 @@ object MinMaxScalerOp extends OpNode[MinMaxScalerModel, MinMaxScalerModel] {
   override val Model: OpModel[MinMaxScalerModel] = new OpModel[MinMaxScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.min_max_scaler
 
-    override def store(context: BundleContext, model: WritableModel, obj: MinMaxScalerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: MinMaxScalerModel): Model = {
       model.withAttr(Attribute("min", Value.doubleVector(obj.originalMin.toArray))).
         withAttr(Attribute("max", Value.doubleVector(obj.originalMax.toArray)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): MinMaxScalerModel = {
+    override def load(context: BundleContext, model: Model): MinMaxScalerModel = {
       new MinMaxScalerModel(uid = "",
         originalMin = Vectors.dense(model.value("min").getDoubleVector.toArray),
         originalMax = Vectors.dense(model.value("max").getDoubleVector.toArray))
@@ -30,7 +30,7 @@ object MinMaxScalerOp extends OpNode[MinMaxScalerModel, MinMaxScalerModel] {
 
   override def model(node: MinMaxScalerModel): MinMaxScalerModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: MinMaxScalerModel): MinMaxScalerModel = {
+  override def load(context: BundleContext, node: Node, model: MinMaxScalerModel): MinMaxScalerModel = {
     new MinMaxScalerModel(uid = node.name, originalMin = model.originalMin, originalMax = model.originalMax)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
@@ -12,11 +12,11 @@ object NormalizerOp extends OpNode[Normalizer, Normalizer] {
   override val Model: OpModel[Normalizer] = new OpModel[Normalizer] {
     override def opName: String = Bundle.BuiltinOps.feature.normalizer
 
-    override def store(context: BundleContext, model: WritableModel, obj: Normalizer): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: Normalizer): Model = {
       model.withAttr(Attribute("p_norm", Value.double(obj.getP)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): Normalizer = {
+    override def load(context: BundleContext, model: Model): Normalizer = {
       new Normalizer(uid = "").setP(model.value("p_norm").getDouble)
     }
   }
@@ -25,7 +25,7 @@ object NormalizerOp extends OpNode[Normalizer, Normalizer] {
 
   override def model(node: Normalizer): Normalizer = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: Normalizer): Normalizer = {
+  override def load(context: BundleContext, node: Node, model: Normalizer): Normalizer = {
     new Normalizer(uid = node.name).copy(model.extractParamMap()).
       setInputCol(node.shape.standardInput.name).
       setOutputCol(node.shape.standardOutput.name)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
@@ -12,11 +12,11 @@ object OneHotEncoderOp extends OpNode[OneHotEncoderModel, OneHotEncoderModel] {
   override val Model: OpModel[OneHotEncoderModel] = new OpModel[OneHotEncoderModel] {
     override def opName: String = Bundle.BuiltinOps.feature.one_hot_encoder
 
-    override def store(context: BundleContext, model: WritableModel, obj: OneHotEncoderModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: OneHotEncoderModel): Model = {
       model.withAttr(Attribute("size", Value.long(obj.size)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): OneHotEncoderModel = {
+    override def load(context: BundleContext, model: Model): OneHotEncoderModel = {
       new OneHotEncoderModel(uid = "", size = model.value("size").getLong.toInt)
     }
   }
@@ -25,7 +25,7 @@ object OneHotEncoderOp extends OpNode[OneHotEncoderModel, OneHotEncoderModel] {
 
   override def model(node: OneHotEncoderModel): OneHotEncoderModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: OneHotEncoderModel): OneHotEncoderModel = {
+  override def load(context: BundleContext, node: Node, model: OneHotEncoderModel): OneHotEncoderModel = {
     new OneHotEncoderModel(uid = node.name, size = model.size)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -12,11 +12,11 @@ object ReverseStringIndexerOp extends OpNode[IndexToString, IndexToString] {
   override val Model: OpModel[IndexToString] = new OpModel[IndexToString] {
     override def opName: String = Bundle.BuiltinOps.feature.reverse_string_indexer
 
-    override def store(context: BundleContext, model: WritableModel, obj: IndexToString): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: IndexToString): Model = {
       model.withAttr(Attribute("labels", Value.stringList(obj.getLabels)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): IndexToString = {
+    override def load(context: BundleContext, model: Model): IndexToString = {
       new IndexToString(uid = "").setLabels(model.value("labels").getStringList.toArray)
     }
   }
@@ -25,7 +25,7 @@ object ReverseStringIndexerOp extends OpNode[IndexToString, IndexToString] {
 
   override def model(node: IndexToString): IndexToString = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: IndexToString): IndexToString = {
+  override def load(context: BundleContext, node: Node, model: IndexToString): IndexToString = {
     new IndexToString(uid = node.name).copy(model.extractParamMap())
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
@@ -13,18 +13,15 @@ object StandardScalerOp extends OpNode[StandardScalerModel, StandardScalerModel]
   override val Model: OpModel[StandardScalerModel] = new OpModel[StandardScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.standard_scaler
 
-    override def store(context: BundleContext, model: WritableModel, obj: StandardScalerModel): WritableModel = {
-      var model2 = model
-      model2 = if(obj.getWithMean) {
-        model2.withAttr(Attribute("mean", Value.doubleVector(obj.mean.toArray)))
-      } else { model2 }
-      model2 = if(obj.getWithStd) {
-        model.withAttr(Attribute("std", Value.doubleVector(obj.std.toArray)))
-      } else { model2 }
-      model2
+    override def store(context: BundleContext, model: Model, obj: StandardScalerModel): Model = {
+      val mean = if(obj.getWithMean) Some(obj.mean) else None
+      val std = if(obj.getWithStd) Some(obj.std) else None
+
+      model.withAttr(mean.map(m => Attribute("mean", Value.doubleVector(m.toArray)))).
+        withAttr(std.map(s => Attribute("std", Value.doubleVector(s.toArray))))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): StandardScalerModel = {
+    override def load(context: BundleContext, model: Model): StandardScalerModel = {
       val std = model.getValue("std").map(_.getDoubleVector.toArray).map(Vectors.dense).orNull
       val mean = model.getValue("mean").map(_.getDoubleVector.toArray).map(Vectors.dense).orNull
       new StandardScalerModel(uid = "", std = std, mean = mean)
@@ -35,7 +32,7 @@ object StandardScalerOp extends OpNode[StandardScalerModel, StandardScalerModel]
 
   override def model(node: StandardScalerModel): StandardScalerModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: StandardScalerModel): StandardScalerModel = {
+  override def load(context: BundleContext, node: Node, model: StandardScalerModel): StandardScalerModel = {
     new StandardScalerModel(uid = node.name, std = model.std, mean = model.mean)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -12,11 +12,11 @@ object StringIndexerOp extends OpNode[StringIndexerModel, StringIndexerModel] {
   override val Model: OpModel[StringIndexerModel] = new OpModel[StringIndexerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.string_indexer
 
-    override def store(context: BundleContext, model: WritableModel, obj: StringIndexerModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: StringIndexerModel): Model = {
       model.withAttr(Attribute("labels", Value.stringList(obj.labels)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): StringIndexerModel = {
+    override def load(context: BundleContext, model: Model): StringIndexerModel = {
       new StringIndexerModel(uid = "", labels = model.value("labels").getStringList.toArray)
     }
   }
@@ -25,7 +25,7 @@ object StringIndexerOp extends OpNode[StringIndexerModel, StringIndexerModel] {
 
   override def model(node: StringIndexerModel): StringIndexerModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: StringIndexerModel): StringIndexerModel = {
+  override def load(context: BundleContext, node: Node, model: StringIndexerModel): StringIndexerModel = {
     new StringIndexerModel(uid = node.name, labels = model.labels)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
@@ -12,16 +12,16 @@ object TokenizerOp extends OpNode[Tokenizer, Tokenizer] {
   override val Model: OpModel[Tokenizer] = new OpModel[Tokenizer] {
     override def opName: String = Bundle.BuiltinOps.feature.tokenizer
 
-    override def store(context: BundleContext, model: WritableModel, obj: Tokenizer): WritableModel = { model }
+    override def store(context: BundleContext, model: Model, obj: Tokenizer): Model = { model }
 
-    override def load(context: BundleContext, model: ReadableModel): Tokenizer = new Tokenizer(uid = "")
+    override def load(context: BundleContext, model: Model): Tokenizer = new Tokenizer(uid = "")
   }
 
   override def name(node: Tokenizer): String = node.uid
 
   override def model(node: Tokenizer): Tokenizer = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: Tokenizer): Tokenizer = {
+  override def load(context: BundleContext, node: Node, model: Tokenizer): Tokenizer = {
     new Tokenizer(uid = node.name)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorAssemblerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/VectorAssemblerOp.scala
@@ -12,16 +12,16 @@ object VectorAssemblerOp extends OpNode[VectorAssembler, VectorAssembler] {
   override val Model: OpModel[VectorAssembler] = new OpModel[VectorAssembler] {
     override def opName: String = Bundle.BuiltinOps.feature.vector_assembler
 
-    override def store(context: BundleContext, model: WritableModel, obj: VectorAssembler): WritableModel = { model }
+    override def store(context: BundleContext, model: Model, obj: VectorAssembler): Model = { model }
 
-    override def load(context: BundleContext, model: ReadableModel): VectorAssembler = { new VectorAssembler(uid = "") }
+    override def load(context: BundleContext, model: Model): VectorAssembler = { new VectorAssembler(uid = "") }
   }
 
   override def name(node: VectorAssembler): String = node.uid
 
   override def model(node: VectorAssembler): VectorAssembler = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: VectorAssembler): VectorAssembler = {
+  override def load(context: BundleContext, node: Node, model: VectorAssembler): VectorAssembler = {
     new VectorAssembler().
       setInputCols(node.shape.inputs.map(_.name).toArray).
       setOutputCol(node.shape.standardOutput.name)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -16,12 +16,12 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegressionModel, Deci
   override val Model: OpModel[DecisionTreeRegressionModel] = new OpModel[DecisionTreeRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.decision_tree_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: DecisionTreeRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: DecisionTreeRegressionModel): Model = {
       TreeSerializer[org.apache.spark.ml.tree.Node](context.file("nodes"), withImpurities = false).write(obj.rootNode)
       model.withAttr(Attribute("num_features", Value.long(obj.numFeatures)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): DecisionTreeRegressionModel = {
+    override def load(context: BundleContext, model: Model): DecisionTreeRegressionModel = {
       val rootNode = TreeSerializer[org.apache.spark.ml.tree.Node](context.file("nodes"), withImpurities = false).read()
       new DecisionTreeRegressionModel(uid = "",
         rootNode = rootNode,
@@ -33,7 +33,7 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegressionModel, Deci
 
   override def model(node: DecisionTreeRegressionModel): DecisionTreeRegressionModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: DecisionTreeRegressionModel): DecisionTreeRegressionModel = {
+  override def load(context: BundleContext, node: Node, model: DecisionTreeRegressionModel): DecisionTreeRegressionModel = {
     new DecisionTreeRegressionModel(uid = node.name,
       rootNode = model.rootNode,
       numFeatures = model.numFeatures).

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
@@ -12,7 +12,7 @@ object GBTRegressionOp extends OpNode[GBTRegressionModel, GBTRegressionModel] {
   override val Model: OpModel[GBTRegressionModel] = new OpModel[GBTRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.gbt_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: GBTRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: GBTRegressionModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -26,7 +26,7 @@ object GBTRegressionOp extends OpNode[GBTRegressionModel, GBTRegressionModel] {
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): GBTRegressionModel = {
+    override def load(context: BundleContext, model: Model): GBTRegressionModel = {
       val numFeatures = model.value("num_features").getLong.toInt
       val treeWeights = model.value("tree_weights").getDoubleList.toArray
 
@@ -45,7 +45,7 @@ object GBTRegressionOp extends OpNode[GBTRegressionModel, GBTRegressionModel] {
 
   override def model(node: GBTRegressionModel): GBTRegressionModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: GBTRegressionModel): GBTRegressionModel = {
+  override def load(context: BundleContext, node: Node, model: GBTRegressionModel): GBTRegressionModel = {
     new GBTRegressionModel(uid = node.name,
       _trees = model.trees,
       _treeWeights = model.treeWeights,

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
@@ -13,12 +13,12 @@ object LinearRegressionOp extends OpNode[LinearRegressionModel, LinearRegression
   override val Model: OpModel[LinearRegressionModel] = new OpModel[LinearRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.linear_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: LinearRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: LinearRegressionModel): Model = {
       model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
         withAttr(Attribute("intercept", Value.double(obj.intercept)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): LinearRegressionModel = {
+    override def load(context: BundleContext, model: Model): LinearRegressionModel = {
       new LinearRegressionModel(uid = "",
         coefficients = Vectors.dense(model.value("coefficients").getDoubleVector.toArray),
         intercept = model.value("intercept").getDouble)
@@ -29,7 +29,7 @@ object LinearRegressionOp extends OpNode[LinearRegressionModel, LinearRegression
 
   override def model(node: LinearRegressionModel): LinearRegressionModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: LinearRegressionModel): LinearRegressionModel = {
+  override def load(context: BundleContext, node: Node, model: LinearRegressionModel): LinearRegressionModel = {
     new LinearRegressionModel(uid = node.name,
       coefficients = model.coefficients,
       intercept = model.intercept).

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -15,7 +15,7 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegressionModel, Rand
   override val Model: OpModel[RandomForestRegressionModel] = new OpModel[RandomForestRegressionModel] {
     override def opName: String = Bundle.BuiltinOps.regression.random_forest_regression
 
-    override def store(context: BundleContext, model: WritableModel, obj: RandomForestRegressionModel): WritableModel = {
+    override def store(context: BundleContext, model: Model, obj: RandomForestRegressionModel): Model = {
       var i = 0
       val trees = obj.trees.map {
         tree =>
@@ -28,7 +28,7 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegressionModel, Rand
         withAttr(Attribute("trees", Value.stringList(trees)))
     }
 
-    override def load(context: BundleContext, model: ReadableModel): RandomForestRegressionModel = {
+    override def load(context: BundleContext, model: Model): RandomForestRegressionModel = {
       val numFeatures = model.value("num_features").getLong.toInt
 
       val models = model.value("trees").getStringList.map {
@@ -45,7 +45,7 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegressionModel, Rand
 
   override def model(node: RandomForestRegressionModel): RandomForestRegressionModel = node
 
-  override def load(context: BundleContext, node: ReadableNode, model: RandomForestRegressionModel): RandomForestRegressionModel = {
+  override def load(context: BundleContext, node: Node, model: RandomForestRegressionModel): RandomForestRegressionModel = {
     new RandomForestRegressionModel(uid = node.name,
       numFeatures = model.numFeatures,
       _trees = model.trees).


### PR DESCRIPTION
This simplifies Bundle.ML object construction by:

1. Make it easier to add optional attributes to an attribute list
2. Make it easier to add optional inputs and outputs to a shape
3. Get rid of Writeable* and Readable* traits since we use immutable objects anywayas