### PR TITLE
Children, PCA Model, and new withAttr methods

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/AttributeList.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/AttributeList.scala
@@ -65,6 +65,22 @@ trait HasAttributeList[T] {
     case (None, None) => replaceAttrList(None)
   }
 
+  /** Add an attribute to the list.
+    *
+    * @param name name of the attribute
+    * @param value value of the attribute
+    * @return a copy of T with the attribute added
+    */
+  def withAttr(name: String, value: Value): T = withAttr(Attribute(name, value))
+
+  /** Add an optional attribute to the list.
+    *
+    * @param name name of the attribute
+    * @param value optional value
+    * @return a copy of T with the attribute optionally added
+    */
+  def withAttr(name: String, value: Option[Value]): T = withAttr(value.map(Attribute(name, _)))
+
   /** Add a list of attributes to [[attributes]].
     *
     * Adds all attributes in the list argument to [[attributes]].

--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -46,6 +46,7 @@ object Bundle {
       val bucketizer = "bucketizer"
       val elementwise_product = "elementwise_product"
       val normalizer = "normalizer"
+      val pca = "pca"
     }
 
     object classification {

--- a/bundle-ml/src/main/scala/ml/combust/bundle/op/OpNode.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/op/OpNode.scala
@@ -35,6 +35,13 @@ trait OpNode[N, M] {
     */
   def shape(node: N): Shape
 
+  /** Get the children of the node.
+    *
+    * @param node node object
+    * @return children of the node
+    */
+  def children(node: N): Option[Array[Any]] = None
+
   /** Load a node from Bundle.ML data.
     *
     * @param context bundle context for decoding custom values and getting non-standard params

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/PipelineOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test_ops/PipelineOp.scala
@@ -34,4 +34,6 @@ object PipelineOp extends OpNode[Pipeline, PipelineModel] {
   }
 
   override def shape(node: Pipeline): Shape = Shape()
+
+  override def children(node: Pipeline): Option[Array[Any]] = Some(node.model.stages.toArray)
 }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/PcaModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/PcaModel.scala
@@ -1,0 +1,29 @@
+package ml.combust.mleap.core.feature
+
+import ml.combust.mleap.core.annotation.SparkCode
+import org.apache.spark.ml.linalg._
+
+/** Class for principal components analysis model.
+  *
+  * @param k number of elements in output vector
+  * @param principalComponents matrix of principal components
+  */
+case class PcaModel(principalComponents: DenseMatrix) {
+  /** Convert input vector to its principal components.
+    *
+    * @param vector vector to transform
+    * @return vector with only principal components
+    */
+  @SparkCode(uri = "https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/mllib/feature/PCA.scala")
+  def apply(vector: Vector): Vector = vector match {
+    case vector: DenseVector =>
+      principalComponents.transpose.multiply(vector)
+    case SparseVector(size, indices, values) =>
+      val sm = Matrices.sparse(size, 1, Array(0, indices.length), indices, values).transpose
+      val projection = sm.multiply(principalComponents)
+      Vectors.dense(projection.values)
+    case _ =>
+      throw new IllegalArgumentException("Unsupported vector format. Expected " +
+        s"SparseVector or DenseVector. Instead got: ${vector.getClass}")
+  }
+}

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/PcaModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/PcaModelSpec.scala
@@ -1,0 +1,20 @@
+package ml.combust.mleap.core.feature
+
+import org.apache.spark.ml.linalg.{DenseMatrix, Matrices, Vectors}
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 10/12/16.
+  */
+class PcaModelSpec extends FunSpec {
+  describe("#apply") {
+    it("uses the principal components matrix to transform a vector to a lower-dimensional vector") {
+      val pc = new DenseMatrix(3, 2, Array[Double](1, -1, 2,
+        0, -3, 1))
+      val input = Vectors.dense(Array[Double](2, 1, 0))
+      val pca = PcaModel(pc)
+
+      assert(pca(input).toArray sameElements Array[Double](1, -3))
+    }
+  }
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/MleapSupport.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/MleapSupport.scala
@@ -2,7 +2,7 @@ package ml.combust.mleap.runtime
 
 import java.io.File
 
-import ml.combust.mleap.runtime.serialization.bundle.MleapBundle
+import ml.combust.mleap.runtime.bundle.MleapBundle
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.bundle.BundleDef.BundleDef
 import ml.combust.bundle.dsl.{AttributeList, Bundle}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/MleapBundle.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/MleapBundle.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle
+package ml.combust.mleap.runtime.bundle
 
 import java.io.File
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/MleapRegistry.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/MleapRegistry.scala
@@ -28,6 +28,7 @@ object MleapRegistry {
     register(ops.feature.BucketizerOp).
     register(ops.feature.ElementwiseProductOp).
     register(ops.feature.NormalizerOp).
+    register(ops.feature.PcaOp).
 
     // regression
     register(ops.regression.LinearRegressionOp).

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/MleapRegistry.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/MleapRegistry.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle
+package ml.combust.mleap.runtime.bundle
 
 import ml.combust.bundle.serializer.BundleRegistry
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/PipelineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/PipelineOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops
+package ml.combust.mleap.runtime.bundle.ops
 
 import ml.combust.mleap.runtime.transformer.{Pipeline, Transformer}
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/PipelineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/PipelineOp.scala
@@ -14,7 +14,7 @@ object PipelineOp extends OpNode[Pipeline, Pipeline] {
 
     override def store(context: BundleContext, model: Model, obj: Pipeline): Model = {
       val nodes = GraphSerializer(context).write(obj.transformers)
-      model.withAttr(Attribute("nodes", Value.stringList(nodes)))
+      model.withAttr("nodes", Value.stringList(nodes))
     }
 
     override def load(context: BundleContext, model: Model): Pipeline = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -20,8 +20,8 @@ object DecisionTreeClassifierOp extends OpNode[DecisionTreeClassifier, DecisionT
 
     override def store(context: BundleContext, model: Model, obj: DecisionTreeClassifierModel): Model = {
       TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("num_classes", Value.long(obj.numClasses)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("num_classes", Value.long(obj.numClasses))
     }
 
     override def load(context: BundleContext, model: Model): DecisionTreeClassifierModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -1,8 +1,8 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.classification
+package ml.combust.mleap.runtime.bundle.ops.classification
 
 import ml.combust.mleap.core.classification.DecisionTreeClassifierModel
 import ml.combust.mleap.core.tree
-import ml.combust.mleap.runtime.serialization.bundle.tree.MleapNodeWrapper
+import ml.combust.mleap.runtime.bundle.tree.MleapNodeWrapper
 import ml.combust.mleap.runtime.transformer.classification.DecisionTreeClassifier
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.BundleContext

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/GBTClassifierOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.classification
+package ml.combust.mleap.runtime.bundle.ops.classification
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/GBTClassifierOp.scala
@@ -23,13 +23,11 @@ object GBTClassifierOp extends OpNode[GBTClassifier, GBTClassifierModel] {
           i = i + 1
           name
       }
-      val m = model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("num_classes", Value.long(2))).
-        withAttr(Attribute("tree_weights", Value.doubleList(obj.treeWeights))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
-      obj.threshold.
-        map(t => m.withAttr(Attribute("threshold", Value.double(t)))).
-        getOrElse(m)
+      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
+        withAttr("num_classes", Value.long(2)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees)).
+        withAttr("threshold", obj.threshold.map(Value.double))
     }
 
     override def load(context: BundleContext, model: Model): GBTClassifierModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/LogisticRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/LogisticRegressionOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.classification
+package ml.combust.mleap.runtime.bundle.ops.classification
 
 import ml.combust.mleap.core.classification.LogisticRegressionModel
 import ml.combust.mleap.runtime.transformer.classification.LogisticRegression

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/LogisticRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/LogisticRegressionOp.scala
@@ -15,10 +15,10 @@ object LogisticRegressionOp extends OpNode[LogisticRegression, LogisticRegressio
     override def opName: String = Bundle.BuiltinOps.classification.logistic_regression
 
     override def store(context: BundleContext, model: Model, obj: LogisticRegressionModel): Model = {
-      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
-        withAttr(Attribute("intercept", Value.double(obj.intercept))).
-        withAttr(Attribute("num_classes", Value.long(2))).
-        withAttr(obj.threshold.map(t => Attribute("threshold", Value.double(t))))
+      model.withAttr("coefficients", Value.doubleVector(obj.coefficients.toArray)).
+        withAttr("intercept", Value.double(obj.intercept)).
+        withAttr("num_classes", Value.long(2)).
+        withAttr("threshold", obj.threshold.map(Value.double))
     }
 
     override def load(context: BundleContext, model: Model): LogisticRegressionModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/OneVsRestOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.classification
+package ml.combust.mleap.runtime.bundle.ops.classification
 
 import ml.combust.mleap.core.classification.{BinaryClassificationModel, OneVsRestModel}
 import ml.combust.mleap.runtime.transformer.classification.OneVsRest

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/OneVsRestOp.scala
@@ -22,7 +22,7 @@ object OneVsRestOp extends OpNode[OneVsRest, OneVsRestModel] {
         name
       }
 
-      model.withAttr(Attribute("num_classes", Value.long(obj.classifiers.length)))
+      model.withAttr("num_classes", Value.long(obj.classifiers.length))
     }
 
     override def load(context: BundleContext, model: Model): OneVsRestModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -25,10 +25,10 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassifier, RandomFor
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("num_classes", Value.long(obj.numClasses))).
-        withAttr(Attribute("tree_weights", Value.doubleList(obj.treeWeights))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("num_classes", Value.long(obj.numClasses)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): RandomForestClassifierModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -1,7 +1,7 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.classification
+package ml.combust.mleap.runtime.bundle.ops.classification
 
 import ml.combust.mleap.core.classification.{DecisionTreeClassifierModel, RandomForestClassifierModel}
-import ml.combust.mleap.runtime.serialization.bundle.tree.MleapNodeWrapper
+import ml.combust.mleap.runtime.bundle.tree.MleapNodeWrapper
 import ml.combust.mleap.runtime.transformer.classification.RandomForestClassifier
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.{BundleContext, ModelSerializer}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/SupportVectorMachineOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.classification
+package ml.combust.mleap.runtime.bundle.ops.classification
 
 import ml.combust.mleap.core.classification.SupportVectorMachineModel
 import ml.combust.mleap.runtime.transformer.classification.SupportVectorMachine

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/classification/SupportVectorMachineOp.scala
@@ -15,10 +15,10 @@ object SupportVectorMachineOp extends OpNode[SupportVectorMachine, SupportVector
     override def opName: String = Bundle.BuiltinOps.classification.support_vector_machine
 
     override def store(context: BundleContext, model: Model, obj: SupportVectorMachineModel): Model = {
-      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
-        withAttr(Attribute("intercept", Value.double(obj.intercept))).
-        withAttr(Attribute("num_classes", Value.long(2))).
-        withAttr(obj.threshold.map(t => Attribute("threshold", Value.double(t))))
+      model.withAttr("coefficients", Value.doubleVector(obj.coefficients.toArray)).
+        withAttr("intercept", Value.double(obj.intercept)).
+        withAttr("num_classes", Value.long(2)).
+        withAttr("threshold", obj.threshold.map(Value.double))
     }
 
     override def load(context: BundleContext, model: Model): SupportVectorMachineModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/clustering/KMeansOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/clustering/KMeansOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.clustering
+package ml.combust.mleap.runtime.bundle.ops.clustering
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/clustering/KMeansOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/clustering/KMeansOp.scala
@@ -15,9 +15,9 @@ object KMeansOp extends OpNode[KMeans, KMeansModel] {
     override def opName: String = Bundle.BuiltinOps.clustering.k_means
 
     override def store(context: BundleContext, model: Model, obj: KMeansModel): Model = {
-      model.withAttr(Attribute("cluster_centers",
+      model.withAttr("cluster_centers",
         Value.tensorList(value = obj.clusterCenters.map(_.vector.toArray.toSeq),
-        dims = Seq(-1))))
+        dims = Seq(-1)))
     }
 
     override def load(context: BundleContext, model: Model): KMeansModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/BucketizerOp.scala
@@ -14,7 +14,7 @@ object BucketizerOp extends OpNode[Bucketizer, BucketizerModel]{
     override def opName: String = Bundle.BuiltinOps.feature.bucketizer
 
     override def store(context: BundleContext, model: Model, obj: BucketizerModel): Model = {
-      model.withAttr(Attribute("splits", Value.doubleList(obj.splits)))
+      model.withAttr("splits", Value.doubleList(obj.splits))
     }
 
     override def load(context: BundleContext, model: Model): BucketizerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/BucketizerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ElementwiseProductOp.scala
@@ -15,7 +15,7 @@ object ElementwiseProductOp extends OpNode[ElementwiseProduct, ElementwiseProduc
     override def opName: String = Bundle.BuiltinOps.feature.elementwise_product
 
     override def store(context: BundleContext, model: Model, obj: ElementwiseProductModel): Model = {
-      model.withAttr(Attribute("scalingVec", Value.doubleVector(obj.scalingVec.toArray)))
+      model.withAttr("scalingVec", Value.doubleVector(obj.scalingVec.toArray))
     }
 
     override def load(context: BundleContext, model: Model): ElementwiseProductModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ElementwiseProductOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -15,7 +15,7 @@ object MaxAbsScalerOp extends OpNode[MaxAbsScaler, MaxAbsScalerModel]{
     override def opName: String = Bundle.BuiltinOps.feature.max_abs_scaler
 
     override def store(context: BundleContext, model: Model, obj: MaxAbsScalerModel): Model = {
-      model.withAttr(Attribute("maxAbs", Value.doubleVector(obj.maxAbs.toArray)))
+      model.withAttr("maxAbs", Value.doubleVector(obj.maxAbs.toArray))
     }
 
     override def load(context: BundleContext, model: Model): MaxAbsScalerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MinMaxScalerOp.scala
@@ -15,8 +15,8 @@ object MinMaxScalerOp extends OpNode[MinMaxScaler, MinMaxScalerModel]{
     override def opName: String = Bundle.BuiltinOps.feature.min_max_scaler
 
     override def store(context: BundleContext, model: Model, obj: MinMaxScalerModel): Model = {
-      model.withAttr(Attribute("min", Value.doubleVector(obj.originalMin.toArray))).
-        withAttr(Attribute("max", Value.doubleVector(obj.originalMax.toArray)))
+      model.withAttr("min", Value.doubleVector(obj.originalMin.toArray)).
+        withAttr("max", Value.doubleVector(obj.originalMax.toArray))
     }
 
     override def load(context: BundleContext, model: Model): MinMaxScalerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/MinMaxScalerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/NormalizerOp.scala
@@ -14,7 +14,7 @@ object NormalizerOp extends OpNode[Normalizer, NormalizerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.normalizer
 
     override def store(context: BundleContext, model: Model, obj: NormalizerModel): Model = {
-      model.withAttr(Attribute("p_norm", Value.double(obj.pNorm)))
+      model.withAttr("p_norm", Value.double(obj.pNorm))
     }
 
     override def load(context: BundleContext, model: Model): NormalizerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/NormalizerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/PcaOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/PcaOp.scala
@@ -1,0 +1,41 @@
+package ml.combust.mleap.runtime.bundle.ops.feature
+
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.bundle.serializer.BundleContext
+import ml.combust.mleap.core.feature.PcaModel
+import ml.combust.mleap.runtime.transformer.feature.Pca
+import org.apache.spark.ml.linalg.DenseMatrix
+
+/**
+  * Created by hollinwilkins on 10/12/16.
+  */
+object PcaOp extends OpNode[Pca, PcaModel] {
+  override val Model: OpModel[PcaModel] = new OpModel[PcaModel] {
+    override def opName: String = Bundle.BuiltinOps.feature.pca
+
+    override def store(context: BundleContext, model: Model, obj: PcaModel): Model = {
+      model.withAttr("principal_components", Value.tensor[Double](obj.principalComponents.values.toSeq,
+        Seq(obj.principalComponents.numRows, obj.principalComponents.numCols)))
+    }
+
+    override def load(context: BundleContext, model: Model): PcaModel = {
+      val tt = model.value("principal_components").bundleDataType.getTensor
+      val values = model.value("principal_components").getTensor[Double].toArray
+      PcaModel(new DenseMatrix(tt.dimensions.head, tt.dimensions(1), values))
+    }
+  }
+
+  override def name(node: Pca): String = node.uid
+
+  override def model(node: Pca): PcaModel = node.model
+
+  override def load(context: BundleContext, node: Node, model: PcaModel): Pca = {
+    Pca(uid = node.name,
+      inputCol = node.shape.standardInput.name,
+      outputCol = node.shape.standardOutput.name,
+      model = model)
+  }
+
+  override def shape(node: Pca): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -14,7 +14,7 @@ object ReverseStringIndexerOp extends OpNode[ReverseStringIndexer, ReverseString
     override def opName: String = Bundle.BuiltinOps.feature.reverse_string_indexer
 
     override def store(context: BundleContext, model: Model, obj: ReverseStringIndexerModel): Model = {
-      model.withAttr(Attribute("labels", Value.stringList(obj.labels)))
+      model.withAttr("labels", Value.stringList(obj.labels))
     }
 
     override def load(context: BundleContext, model: Model): ReverseStringIndexerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.mleap.core.feature.ReverseStringIndexerModel
 import ml.combust.mleap.runtime.transformer.feature.ReverseStringIndexer

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StandardScalerOp.scala
@@ -15,8 +15,8 @@ object StandardScalerOp extends OpNode[StandardScaler, StandardScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.standard_scaler
 
     override def store(context: BundleContext, model: Model, obj: StandardScalerModel): Model = {
-      model.withAttr(obj.mean.map(m => Attribute("mean", Value.doubleVector(m.toArray)))).
-        withAttr(obj.std.map(s => Attribute("std", Value.doubleVector(s.toArray))))
+      model.withAttr("mean", obj.mean.map(_.toArray.toSeq).map(Value.doubleVector)).
+        withAttr("std", obj.mean.map(_.toArray.toSeq).map(Value.doubleVector))
     }
 
     override def load(context: BundleContext, model: Model): StandardScalerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StandardScalerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.mleap.core.feature.StandardScalerModel
 import ml.combust.mleap.runtime.transformer.feature.StandardScaler

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StringIndexerOp.scala
@@ -14,7 +14,7 @@ object StringIndexerOp extends OpNode[StringIndexer, StringIndexerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.string_indexer
 
     override def store(context: BundleContext, model: Model, obj: StringIndexerModel): Model = {
-      model.withAttr(Attribute("labels", Value.stringList(obj.labels)))
+      model.withAttr("labels", Value.stringList(obj.labels))
     }
 
     override def load(context: BundleContext, model: Model): StringIndexerModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/StringIndexerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.mleap.core.feature.StringIndexerModel
 import ml.combust.mleap.runtime.transformer.feature.StringIndexer

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/VectorAssemblerOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/feature/VectorAssemblerOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.feature
+package ml.combust.mleap.runtime.bundle.ops.feature
 
 import ml.combust.mleap.core.feature.VectorAssemblerModel
 import ml.combust.mleap.runtime.transformer.feature.VectorAssembler

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -20,7 +20,7 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegression, DecisionT
 
     override def store(context: BundleContext, model: Model, obj: DecisionTreeRegressionModel): Model = {
       TreeSerializer[tree.Node](context.file("nodes"), withImpurities = false).write(obj.rootNode)
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures)))
+      model.withAttr("num_features", Value.long(obj.numFeatures))
     }
 
     override def load(context: BundleContext, model: Model): DecisionTreeRegressionModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -1,8 +1,8 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.regression
+package ml.combust.mleap.runtime.bundle.ops.regression
 
 import ml.combust.mleap.core.regression.DecisionTreeRegressionModel
 import ml.combust.mleap.core.tree
-import ml.combust.mleap.runtime.serialization.bundle.tree.MleapNodeWrapper
+import ml.combust.mleap.runtime.bundle.tree.MleapNodeWrapper
 import ml.combust.mleap.runtime.transformer.regression.DecisionTreeRegression
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.BundleContext

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/GBTRegressionOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.regression
+package ml.combust.mleap.runtime.bundle.ops.regression
 
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/GBTRegressionOp.scala
@@ -22,9 +22,9 @@ object GBTRegressionOp extends OpNode[GBTRegression, GBTRegressionModel] {
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("tree_weights", Value.doubleList(obj.treeWeights))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): GBTRegressionModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/LinearRegressionOp.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.regression
+package ml.combust.mleap.runtime.bundle.ops.regression
 
 import ml.combust.mleap.core.regression.LinearRegressionModel
 import ml.combust.mleap.runtime.transformer.regression.LinearRegression

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/LinearRegressionOp.scala
@@ -15,8 +15,8 @@ object LinearRegressionOp extends OpNode[LinearRegression, LinearRegressionModel
     override def opName: String = Bundle.BuiltinOps.regression.linear_regression
 
     override def store(context: BundleContext, model: Model, obj: LinearRegressionModel): Model = {
-      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
-        withAttr(Attribute("intercept", Value.double(obj.intercept)))
+      model.withAttr("coefficients", Value.doubleVector(obj.coefficients.toArray)).
+        withAttr("intercept", Value.double(obj.intercept))
     }
 
     override def load(context: BundleContext, model: Model): LinearRegressionModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -1,7 +1,7 @@
-package ml.combust.mleap.runtime.serialization.bundle.ops.regression
+package ml.combust.mleap.runtime.bundle.ops.regression
 
 import ml.combust.mleap.core.regression.{DecisionTreeRegressionModel, RandomForestRegressionModel}
-import ml.combust.mleap.runtime.serialization.bundle.tree.MleapNodeWrapper
+import ml.combust.mleap.runtime.bundle.tree.MleapNodeWrapper
 import ml.combust.mleap.runtime.transformer.regression.RandomForestRegression
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.serializer.{BundleContext, ModelSerializer}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -25,9 +25,9 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegression, RandomFor
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("tree_weights", Value.doubleList(obj.treeWeights))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): RandomForestRegressionModel = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/tree/MleapNodeWrapper.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/bundle/tree/MleapNodeWrapper.scala
@@ -1,4 +1,4 @@
-package ml.combust.mleap.runtime.serialization.bundle.tree
+package ml.combust.mleap.runtime.bundle.tree
 
 import ml.combust.mleap.core.tree
 import ml.bundle.tree.Split.Split

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Pca.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Pca.scala
@@ -1,0 +1,23 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.PcaModel
+import ml.combust.mleap.runtime.transformer.Transformer
+import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
+import ml.combust.mleap.runtime.types.TensorType
+
+import scala.util.Try
+
+/**
+  * Created by hollinwilkins on 10/12/16.
+  */
+case class Pca(override val uid: String = Transformer.uniqueName("pca"),
+               inputCol: String,
+               outputCol: String,
+               model: PcaModel) extends Transformer {
+  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
+    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
+      case (b, inputIndex) =>
+        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/PcaSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/PcaSpec.scala
@@ -1,0 +1,38 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.PcaModel
+import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
+import ml.combust.mleap.runtime.types.{StructField, StructType, TensorType}
+import org.apache.spark.ml.linalg.{DenseMatrix, Vectors}
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 10/12/16.
+  */
+class PcaSpec extends FunSpec {
+  val schema = StructType(Seq(StructField("test_vec", TensorType.doubleVector()))).get
+  val dataset = LocalDataset(Array(Row(Vectors.dense(Array[Double](2.0, 1.0, 0.0)))))
+  val frame = LeapFrame(schema, dataset)
+
+  val pc = new DenseMatrix(3, 2, Array(1d, -1, 2,
+    0, -3, 1))
+  val input = Vectors.dense(Array(2d, 1, 0))
+  val pca = Pca(inputCol = "test_vec",
+    outputCol = "test_pca",
+    model = PcaModel(pc))
+
+  describe("#transform") {
+    it("extracts the principal components from the input column") {
+      val frame2 = pca.transform(frame).get
+      val data = frame2.dataset.toArray(0).getVector(1).toArray
+
+      assert(data sameElements Array[Double](1, -3))
+    }
+
+    describe("with invalid input column") {
+      val pca2 = pca.copy(inputCol = "bad_input")
+
+      it("returns a Failure") { assert(pca2.transform(frame).isFailure) }
+    }
+  }
+}

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/SparkRegistry.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/SparkRegistry.scala
@@ -36,6 +36,7 @@ object SparkRegistry {
       register(ops.feature.MaxAbsScalerOp).
       register(ops.feature.BucketizerOp).
       register(ops.feature.ElementwiseProductOp).
+      register(ops.feature.PcaOp).
 
       // other
       register(ops.PipelineOp)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
@@ -14,7 +14,7 @@ object PipelineOp extends OpNode[PipelineModel, PipelineModel] {
 
     override def store(context: BundleContext, model: Model, obj: PipelineModel): Model = {
       val nodes = GraphSerializer(context).write(obj.stages)
-      model.withAttr(Attribute("nodes", Value.stringList(nodes)))
+      model.withAttr("nodes", Value.stringList(nodes))
     }
 
     override def load(context: BundleContext, model: Model): PipelineModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/PipelineOp.scala
@@ -32,4 +32,6 @@ object PipelineOp extends OpNode[PipelineModel, PipelineModel] {
   }
 
   override def shape(node: PipelineModel): Shape = Shape()
+
+  override def children(node: PipelineModel): Option[Array[Any]] = Some(node.stages.toArray)
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/DecisionTreeClassifierOp.scala
@@ -19,8 +19,8 @@ object DecisionTreeClassifierOp extends OpNode[DecisionTreeClassificationModel, 
 
     override def store(context: BundleContext, model: Model, obj: DecisionTreeClassificationModel): Model = {
       TreeSerializer[tree.Node](context.file("nodes"), withImpurities = true).write(obj.rootNode)
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("num_classes", Value.long(obj.numClasses)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("num_classes", Value.long(obj.numClasses))
     }
 
     override def load(context: BundleContext, model: Model): DecisionTreeClassificationModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/GBTClassifierOp.scala
@@ -22,10 +22,10 @@ object GBTClassifierOp extends OpNode[GBTClassificationModel, GBTClassificationM
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("num_classes", Value.long(2))).
-        withAttr(Attribute("tree_weights", Value.doubleList(obj.treeWeights))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("num_classes", Value.long(2)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): GBTClassificationModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOp.scala
@@ -14,10 +14,10 @@ object LogisticRegressionOp extends OpNode[LogisticRegressionModel, LogisticRegr
     override def opName: String = Bundle.BuiltinOps.classification.logistic_regression
 
     override def store(context: BundleContext, model: Model, obj: LogisticRegressionModel): Model = {
-      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
-        withAttr(Attribute("intercept", Value.double(obj.intercept))).
-        withAttr(Attribute("num_classes", Value.long(obj.numClasses))).
-        withAttr(obj.get(obj.threshold).map(t => Attribute("threshold", Value.double(t))))
+      model.withAttr("coefficients", Value.doubleVector(obj.coefficients.toArray)).
+        withAttr("intercept", Value.double(obj.intercept)).
+        withAttr("num_classes", Value.long(obj.numClasses)).
+        withAttr("threshold", obj.get(obj.threshold).map(Value.double))
     }
 
     override def load(context: BundleContext, model: Model): LogisticRegressionModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/OneVsRestOp.scala
@@ -23,7 +23,7 @@ object OneVsRestOp extends OpNode[OneVsRestModel, OneVsRestModel] {
         name
       }
 
-      model.withAttr(Attribute("num_classes", Value.long(obj.models.length)))
+      model.withAttr("num_classes", Value.long(obj.models.length))
     }
 
     override def load(context: BundleContext, model: Model): OneVsRestModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -24,9 +24,9 @@ object RandomForestClassifierOp extends OpNode[RandomForestClassificationModel, 
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("num_classes", Value.long(obj.numClasses))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("num_classes", Value.long(obj.numClasses)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): RandomForestClassificationModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/SupportVectorMachineOp.scala
@@ -15,10 +15,10 @@ object SupportVectorMachineOp extends OpNode[SVMModel, SVMModel] {
     override def opName: String = Bundle.BuiltinOps.classification.support_vector_machine
 
     override def store(context: BundleContext, model: Model, obj: SVMModel): Model = {
-      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.model.weights.toArray))).
-        withAttr(Attribute("intercept", Value.double(obj.model.intercept))).
-        withAttr(Attribute("num_classes", Value.long(2))).
-        withAttr(obj.get(obj.threshold).map(t => Attribute("threshold", Value.double(t))))
+      model.withAttr("coefficients", Value.doubleVector(obj.model.weights.toArray)).
+        withAttr("intercept", Value.double(obj.model.intercept)).
+        withAttr("num_classes", Value.long(2)).
+        withAttr("threshold", obj.get(obj.threshold).map(Value.double))
     }
 
     override def load(context: BundleContext, model: Model): SVMModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/KMeansOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/KMeansOp.scala
@@ -16,9 +16,9 @@ object KMeansOp extends OpNode[KMeansModel, KMeansModel] {
     override def opName: String = Bundle.BuiltinOps.clustering.k_means
 
     override def store(context: BundleContext, model: Model, obj: KMeansModel): Model = {
-      model.withAttr(Attribute("cluster_centers", Value.tensorList(
+      model.withAttr("cluster_centers", Value.tensorList(
         value = obj.clusterCenters.map(_.toArray.toSeq),
-        dims = Seq(-1))))
+        dims = Seq(-1)))
     }
 
     override def load(context: BundleContext, model: Model): KMeansModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -13,7 +13,7 @@ object BucketizerOp extends OpNode[Bucketizer, Bucketizer] {
     override def opName: String = Bundle.BuiltinOps.feature.bucketizer
 
     override def store(context: BundleContext, model: Model, obj: Bucketizer): Model = {
-      model.withAttr(Attribute("splits", Value.doubleList(obj.getSplits)))
+      model.withAttr("splits", Value.doubleList(obj.getSplits))
     }
 
     override def load(context: BundleContext, model: Model): Bucketizer = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
@@ -14,7 +14,7 @@ object ElementwiseProductOp extends OpNode[ElementwiseProduct, ElementwiseProduc
     override def opName: String = Bundle.BuiltinOps.feature.elementwise_product
 
     override def store(context: BundleContext, model: Model, obj: ElementwiseProduct): Model = {
-      model.withAttr(Attribute("scaling_vec", Value.doubleVector(obj.getScalingVec.toArray)))
+      model.withAttr("scaling_vec", Value.doubleVector(obj.getScalingVec.toArray))
     }
 
     override def load(context: BundleContext, model: Model): ElementwiseProduct = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/HashingTermFrequencyOp.scala
@@ -13,8 +13,8 @@ object HashingTermFrequencyOp extends OpNode[HashingTF, HashingTF] {
     override def opName: String = Bundle.BuiltinOps.feature.hashing_term_frequency
 
     override def store(context: BundleContext, model: Model, obj: HashingTF): Model = {
-      model.withAttr(Attribute("num_features", Value.long(obj.getNumFeatures))).
-        withAttr(Attribute("binary", Value.boolean(obj.getBinary)))
+      model.withAttr("num_features", Value.long(obj.getNumFeatures)).
+        withAttr("binary", Value.boolean(obj.getBinary))
     }
 
     override def load(context: BundleContext, model: Model): HashingTF = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MaxAbsScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MaxAbsScalerOp.scala
@@ -14,7 +14,7 @@ object MaxAbsScalerOp extends OpNode[MaxAbsScalerModel, MaxAbsScalerModel]{
     override def opName: String = Bundle.BuiltinOps.feature.max_abs_scaler
 
     override def store(context: BundleContext, model: Model, obj: MaxAbsScalerModel): Model = {
-      model.withAttr(Attribute("maxAbs", Value.doubleVector(obj.maxAbs.toArray)))
+      model.withAttr("maxAbs", Value.doubleVector(obj.maxAbs.toArray))
   }
 
     override def load(context: BundleContext, model: Model): MaxAbsScalerModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/MinMaxScalerOp.scala
@@ -14,8 +14,8 @@ object MinMaxScalerOp extends OpNode[MinMaxScalerModel, MinMaxScalerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.min_max_scaler
 
     override def store(context: BundleContext, model: Model, obj: MinMaxScalerModel): Model = {
-      model.withAttr(Attribute("min", Value.doubleVector(obj.originalMin.toArray))).
-        withAttr(Attribute("max", Value.doubleVector(obj.originalMax.toArray)))
+      model.withAttr("min", Value.doubleVector(obj.originalMin.toArray)).
+        withAttr("max", Value.doubleVector(obj.originalMax.toArray))
     }
 
     override def load(context: BundleContext, model: Model): MinMaxScalerModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
@@ -13,7 +13,7 @@ object NormalizerOp extends OpNode[Normalizer, Normalizer] {
     override def opName: String = Bundle.BuiltinOps.feature.normalizer
 
     override def store(context: BundleContext, model: Model, obj: Normalizer): Model = {
-      model.withAttr(Attribute("p_norm", Value.double(obj.getP)))
+      model.withAttr("p_norm", Value.double(obj.getP))
     }
 
     override def load(context: BundleContext, model: Model): Normalizer = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/OneHotEncoderOp.scala
@@ -13,7 +13,7 @@ object OneHotEncoderOp extends OpNode[OneHotEncoderModel, OneHotEncoderModel] {
     override def opName: String = Bundle.BuiltinOps.feature.one_hot_encoder
 
     override def store(context: BundleContext, model: Model, obj: OneHotEncoderModel): Model = {
-      model.withAttr(Attribute("size", Value.long(obj.size)))
+      model.withAttr("size", Value.long(obj.size))
     }
 
     override def load(context: BundleContext, model: Model): OneHotEncoderModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PcaOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/PcaOp.scala
@@ -1,0 +1,41 @@
+package org.apache.spark.ml.bundle.ops.feature
+
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.bundle.serializer.BundleContext
+import org.apache.spark.ml.feature.PCAModel
+import org.apache.spark.ml.linalg.{DenseMatrix, DenseVector}
+
+/**
+  * Created by hollinwilkins on 10/12/16.
+  */
+object PcaOp extends OpNode[PCAModel, PCAModel] {
+  override val Model: OpModel[PCAModel] = new OpModel[PCAModel] {
+    override def opName: String = Bundle.BuiltinOps.feature.pca
+
+    override def store(context: BundleContext, model: Model, obj: PCAModel): Model = {
+      model.withAttr("principal_components", Value.tensor[Double](obj.pc.values.toSeq,
+        Seq(obj.pc.numRows, obj.pc.numCols)))
+    }
+
+    override def load(context: BundleContext, model: Model): PCAModel = {
+      val tt = model.value("principal_components").bundleDataType.getTensor
+      val values = model.value("principal_components").getTensor[Double].toArray
+      new PCAModel(uid = "",
+        pc = new DenseMatrix(tt.dimensions.head, tt.dimensions(1), values),
+        explainedVariance = new DenseVector(Array()))
+    }
+  }
+
+  override def name(node: PCAModel): String = node.uid
+
+  override def model(node: PCAModel): PCAModel = node
+
+  override def load(context: BundleContext, node: Node, model: PCAModel): PCAModel = {
+    new PCAModel(uid = node.name,
+      pc = model.pc,
+      explainedVariance = model.explainedVariance)
+  }
+
+  override def shape(node: PCAModel): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+}

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -13,7 +13,7 @@ object ReverseStringIndexerOp extends OpNode[IndexToString, IndexToString] {
     override def opName: String = Bundle.BuiltinOps.feature.reverse_string_indexer
 
     override def store(context: BundleContext, model: Model, obj: IndexToString): Model = {
-      model.withAttr(Attribute("labels", Value.stringList(obj.getLabels)))
+      model.withAttr("labels", Value.stringList(obj.getLabels))
     }
 
     override def load(context: BundleContext, model: Model): IndexToString = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StandardScalerOp.scala
@@ -14,11 +14,11 @@ object StandardScalerOp extends OpNode[StandardScalerModel, StandardScalerModel]
     override def opName: String = Bundle.BuiltinOps.feature.standard_scaler
 
     override def store(context: BundleContext, model: Model, obj: StandardScalerModel): Model = {
-      val mean = if(obj.getWithMean) Some(obj.mean) else None
-      val std = if(obj.getWithStd) Some(obj.std) else None
+      val mean = if(obj.getWithMean) Some(obj.mean.toArray.toSeq) else None
+      val std = if(obj.getWithStd) Some(obj.std.toArray.toSeq) else None
 
-      model.withAttr(mean.map(m => Attribute("mean", Value.doubleVector(m.toArray)))).
-        withAttr(std.map(s => Attribute("std", Value.doubleVector(s.toArray))))
+      model.withAttr("mean", mean.map(Value.doubleVector)).
+        withAttr("std", std.map(Value.doubleVector))
     }
 
     override def load(context: BundleContext, model: Model): StandardScalerModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/StringIndexerOp.scala
@@ -13,7 +13,7 @@ object StringIndexerOp extends OpNode[StringIndexerModel, StringIndexerModel] {
     override def opName: String = Bundle.BuiltinOps.feature.string_indexer
 
     override def store(context: BundleContext, model: Model, obj: StringIndexerModel): Model = {
-      model.withAttr(Attribute("labels", Value.stringList(obj.labels)))
+      model.withAttr("labels", Value.stringList(obj.labels))
     }
 
     override def load(context: BundleContext, model: Model): StringIndexerModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/DecisionTreeRegressionOp.scala
@@ -18,7 +18,7 @@ object DecisionTreeRegressionOp extends OpNode[DecisionTreeRegressionModel, Deci
 
     override def store(context: BundleContext, model: Model, obj: DecisionTreeRegressionModel): Model = {
       TreeSerializer[org.apache.spark.ml.tree.Node](context.file("nodes"), withImpurities = false).write(obj.rootNode)
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures)))
+      model.withAttr("num_features", Value.long(obj.numFeatures))
     }
 
     override def load(context: BundleContext, model: Model): DecisionTreeRegressionModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
@@ -21,9 +21,9 @@ object GBTRegressionOp extends OpNode[GBTRegressionModel, GBTRegressionModel] {
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("tree_weights", Value.doubleList(obj.treeWeights))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("tree_weights", Value.doubleList(obj.treeWeights)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): GBTRegressionModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/LinearRegressionOp.scala
@@ -14,8 +14,8 @@ object LinearRegressionOp extends OpNode[LinearRegressionModel, LinearRegression
     override def opName: String = Bundle.BuiltinOps.regression.linear_regression
 
     override def store(context: BundleContext, model: Model, obj: LinearRegressionModel): Model = {
-      model.withAttr(Attribute("coefficients", Value.doubleVector(obj.coefficients.toArray))).
-        withAttr(Attribute("intercept", Value.double(obj.intercept)))
+      model.withAttr("coefficients", Value.doubleVector(obj.coefficients.toArray)).
+        withAttr("intercept", Value.double(obj.intercept))
     }
 
     override def load(context: BundleContext, model: Model): LinearRegressionModel = {

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -24,8 +24,8 @@ object RandomForestRegressionOp extends OpNode[RandomForestRegressionModel, Rand
           i = i + 1
           name
       }
-      model.withAttr(Attribute("num_features", Value.long(obj.numFeatures))).
-        withAttr(Attribute("trees", Value.stringList(trees)))
+      model.withAttr("num_features", Value.long(obj.numFeatures)).
+        withAttr("trees", Value.stringList(trees))
     }
 
     override def load(context: BundleContext, model: Model): RandomForestRegressionModel = {


### PR DESCRIPTION
This PR has several changes:
1. children method for OpNode to get at the children objects
2. PCA model for principal components analysis
3. withAttr methods that are easier to use