### PR TITLE
Add in user defined functions up to 5 arguments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val `mleap-runtime` = project.in(file("mleap-runtime")).
   settings(Common.settings).
   settings(Common.combustSettings).
   settings(Common.sonatypeSettings).
-  settings(libraryDependencies ++= Dependencies.mleapRuntimeDependencies).
+  settings(libraryDependencies ++= Dependencies.mleapRuntimeDependencies(scalaVersion.value)).
   dependsOn(`mleap-core`, `bundle-ml`)
 
 lazy val `mleap-spark` = project.in(file("mleap-spark")).

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/ClassificationModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/ClassificationModel.scala
@@ -94,7 +94,7 @@ trait BinaryClassificationModel extends ClassificationModel {
     (probabilityToPrediction(probability), probability)
   }
 
-  private def probabilityToPrediction(probability: Double): Double = threshold match {
+  def probabilityToPrediction(probability: Double): Double = threshold match {
     case Some(t) => if (probability > t) 1.0 else 0.0
     case None => probability
   }

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/OneVsRestModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/OneVsRestModel.scala
@@ -27,6 +27,10 @@ case class OneVsRestModel(classifiers: Array[BinaryClassificationModel]) {
     predictWithProbability(features)._1
   }
 
+  def predictProbability(features: Vector): Double = {
+    predictWithProbability(features)._2
+  }
+
   /** Predict the class and probability for a feature vector.
     *
     * @param features feature vector

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/KMeansModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/clustering/KMeansModel.scala
@@ -17,9 +17,9 @@ object KMeansModel {
 case class KMeansModel(clusterCenters: Array[VectorWithNorm]) {
   def clusterCount: Int = clusterCenters.length
 
-  def apply(features: Vector): Int = predict(features)
+  def apply(features: Vector): Double = predict(features)
 
-  def predict(features: Vector): Int = {
+  def predict(features: Vector): Double = {
     findClosest(VectorWithNorm(features))._1
   }
 

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorAssemblerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorAssemblerModel.scala
@@ -25,7 +25,7 @@ case class VectorAssemblerModel() extends Serializable {
     * @param vv all input feature values
     * @return assembled vector
     */
-  def apply(vv: Any *): Vector = {
+  def apply(vv: Array[Any]): Vector = {
     val indices = mutable.ArrayBuilder.make[Int]
     val values = mutable.ArrayBuilder.make[Double]
     var cur = 0

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
@@ -12,10 +12,10 @@ class VectorAssemblerModelSpec extends FunSpec {
       val assembler = VectorAssemblerModel.default
       val expectedArray = Array(45.0, 76.8, 23.0, 45.6, 0.0, 22.3, 45.6, 0.0, 99.3)
 
-      assert(assembler(45.0,
+      assert(assembler(Array(45.0,
         76.8,
         Vectors.dense(Array(23.0, 45.6)),
-        Vectors.sparse(5, Array(1, 2, 4), Array(22.3, 45.6, 99.3))).toArray.sameElements(expectedArray))
+        Vectors.sparse(5, Array(1, 2, 4), Array(22.3, 45.6, 99.3)))).toArray.sameElements(expectedArray))
     }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
@@ -1,5 +1,7 @@
 package ml.combust.mleap.runtime
 
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+
 /** Trait for storing data in a [[ml.combust.mleap.runtime.LeapFrame]].
   */
 trait Dataset extends Serializable {
@@ -9,6 +11,14 @@ trait Dataset extends Serializable {
     * @return dataset with updated rows
     */
   def update(f: (Row) => Row): Dataset
+
+  /** Add a value to every row using a user defined function.
+    *
+    * @param indices input indices to the udf
+    * @param udf user defined function
+    * @return dataset with value calculated for all rows
+    */
+  def withValue(indices: Array[Int])(udf: UserDefinedFunction): Dataset = update(_.withValue(indices)(udf))
 
   /** Add a value to every row.
     *

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
@@ -1,5 +1,6 @@
 package ml.combust.mleap.runtime
 
+import ml.combust.mleap.runtime.Row.RowSelector
 import ml.combust.mleap.runtime.function.UserDefinedFunction
 
 /** Trait for storing data in a [[ml.combust.mleap.runtime.LeapFrame]].
@@ -14,18 +15,12 @@ trait Dataset extends Serializable {
 
   /** Add a value to every row using a user defined function.
     *
-    * @param indices input indices to the udf
+    * @param selectors row selectors to generate inputs to UDF
     * @param udf user defined function
     * @return dataset with value calculated for all rows
     */
-  def withValue(indices: Int *)(udf: UserDefinedFunction): Dataset = update(_.withValue(indices: _*)(udf))
-
-  /** Add a value to every row.
-    *
-    * @param f function used to calculate value for a row
-    * @return dataset with new value
-    */
-  def withValue(f: (Row) => Any): Dataset = update(_.withValue(f))
+  def withValue(selectors: RowSelector *)
+               (udf: UserDefinedFunction): Dataset = update(_.withValue(selectors: _*)(udf))
 
   /** Add values to every row.
     *

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
@@ -22,13 +22,6 @@ trait Dataset extends Serializable {
   def withValue(selectors: RowSelector *)
                (udf: UserDefinedFunction): Dataset = update(_.withValue(selectors: _*)(udf))
 
-  /** Add values to every row.
-    *
-    * @param f function used to calculate additional values for every row
-    * @return dataset with new values
-    */
-  def withValues(f: (Row) => Row): Dataset = update(_.withValues(f))
-
   /** Select given indices of every row.
     *
     * @param indices indices to select

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Dataset.scala
@@ -18,7 +18,7 @@ trait Dataset extends Serializable {
     * @param udf user defined function
     * @return dataset with value calculated for all rows
     */
-  def withValue(indices: Array[Int])(udf: UserDefinedFunction): Dataset = update(_.withValue(indices)(udf))
+  def withValue(indices: Int *)(udf: UserDefinedFunction): Dataset = update(_.withValue(indices: _*)(udf))
 
   /** Add a value to every row.
     *

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
@@ -118,37 +118,6 @@ trait LeapFrame[LF <: LeapFrame[LF]] extends TransformBuilder[LF] with Serializa
     }
   }
 
-  /** Try to add multiple fields to the LeapFrame.
-    *
-    * Returns a Failure if trying to add any existing fields.
-    *
-    * @param field first field to add
-    * @param fields fields to add
-    * @param f function for calculating new field values
-    * @return try new LeapFrame with new fields
-    */
-  def withFields(field: StructField, fields: StructField *)
-                (f: (Row) => Row): Try[LF] = {
-    withFields(field +: fields)(f)
-  }
-
-  /** Try to add multiple fields to the LeapFrame.
-    *
-    * Returns a Failure if trying to add any existing fields.
-    *
-    * @param fields fields to add
-    * @param f function for calculating new field values
-    * @return try new LeapFrame with new fields
-    */
-  def withFields(fields: Seq[StructField])
-                (f: (Row) => Row): Try[LF] = {
-    schema.withFields(fields).map {
-      schema2 =>
-        val dataset2 = dataset.withValues(f)
-        withSchemaAndDataset(schema2, dataset2)
-    }
-  }
-
   /** Try to drop a field from the LeapFrame.
     *
     * Returns a Failure if the field does not exist.

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
@@ -1,7 +1,7 @@
 package ml.combust.mleap.runtime
 
 import ml.combust.mleap.runtime.Row.RowSelector
-import ml.combust.mleap.runtime.function.{FieldSelector, MultipleFieldSelector, Selector, UserDefinedFunction}
+import ml.combust.mleap.runtime.function.{FieldSelector, ArraySelector, Selector, UserDefinedFunction}
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
 import ml.combust.mleap.runtime.types._
 
@@ -67,7 +67,7 @@ trait LeapFrame[LF <: LeapFrame[LF]] extends TransformBuilder[LF] with Serializa
             Failure(new IllegalArgumentException(s"field $name data type ${field.dataType} does not match $dataType"))
           }
       }
-    case MultipleFieldSelector(fields @ _*) =>
+    case ArraySelector(fields @ _*) =>
       if(dataType == ListType(AnyType)) {
         schema.indicesOf(fields: _*).map {
           indices =>

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/LeapFrame.scala
@@ -60,13 +60,13 @@ trait LeapFrame[LF <: LeapFrame[LF]] extends TransformBuilder[LF] with Serializa
     * @param udf user defined function for calculating field value
     * @return try new LeapFrame with new field
     */
-  def withField(name: String, fields: Seq[String])
+  def withField(name: String, fields: String *)
                (udf: UserDefinedFunction): Try[LF] = {
     schema.withField(name, udf.returnType).flatMap {
       schema2 =>
         withInputs(fields.zip(udf.inputs)).map {
           case (frame, indices) =>
-            val dataset2 = dataset.withValue(indices)(udf)
+            val dataset2 = dataset.withValue(indices: _*)(udf)
             withSchemaAndDataset(schema2, dataset2)
         }
     }
@@ -169,8 +169,8 @@ trait LeapFrame[LF <: LeapFrame[LF]] extends TransformBuilder[LF] with Serializa
     }
   }
 
-  override def withInputs(fields: Seq[(String, DataType)]): Try[(LF, Array[Int])] = {
-    fields.foldLeft(Try((lf, Array[Int]()))) {
+  override def withInputs(fields: Seq[(String, DataType)]): Try[(LF, Seq[Int])] = {
+    fields.foldLeft(Try((lf, Seq[Int]()))) {
       case (lfs, (name, dataType)) =>
         schema.indexedField(name).flatMap {
           case (index, field) =>
@@ -188,7 +188,7 @@ trait LeapFrame[LF <: LeapFrame[LF]] extends TransformBuilder[LF] with Serializa
   override def withOutput(name: String,
                           fields: String *)
                          (udf: UserDefinedFunction): Try[LF] = {
-    withField(name, fields)(udf)
+    withField(name, fields: _*)(udf)
   }
 
   override def withOutput(name: String, dataType: DataType)(o: (Row) => Any): Try[LF] = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -109,52 +109,31 @@ trait Row {
     udf.inputs.length match {
       case 0 =>
         val f = udf.f.asInstanceOf[() => Any]
-        withLiteral(f())
+        withValue(f())
       case 1 =>
         val f = udf.f.asInstanceOf[(Any) => Any]
-        withLiteral(f(selectors.head(this)))
+        withValue(f(selectors.head(this)))
       case 2 =>
         val f = udf.f.asInstanceOf[(Any, Any) => Any]
-        withLiteral(f(selectors.head(this), selectors(1)(this)))
+        withValue(f(selectors.head(this), selectors(1)(this)))
       case 3 =>
         val f = udf.f.asInstanceOf[(Any, Any, Any) => Any]
-        withLiteral(f(selectors.head(this), selectors(1)(this), selectors(2)(this)))
+        withValue(f(selectors.head(this), selectors(1)(this), selectors(2)(this)))
       case 4 =>
         val f = udf.f.asInstanceOf[(Any, Any, Any, Any) => Any]
-        withLiteral(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this)))
+        withValue(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this)))
       case 5 =>
         val f = udf.f.asInstanceOf[(Any, Any, Any, Any, Any) => Any]
-        withLiteral(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this), selectors(4)(this)))
+        withValue(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this), selectors(4)(this)))
     }
   }
-
-  /** Add a value to the row.
-    *
-    * @param f function for calculating new value
-    * @return row with new value
-    */
-  def withValue(f: (Row) => Any): Row = withLiteral(f(this))
-
-  /** Add multiple values to the row.
-    *
-    * @param f function for calculating new row values
-    * @return row with new values
-    */
-  def withValues(f: (Row) => Row): Row = withValues(f(this))
-
-  /** Add multiple values to the row.
-    *
-    * @param values row with values to add
-    * @return row with new values
-    */
-  def withValues(values: Row): Row
 
   /** Add a value to the row.
     *
     * @param value value to add
     * @return row with the new value
     */
-  def withLiteral(value: Any): Row
+  def withValue(value: Any): Row
 
   /** Create a new row from specified indices.
     *
@@ -187,8 +166,7 @@ case class ArrayRow(values: Array[Any]) extends Row {
   override def toSeq: Seq[Any] = values.toSeq
   override def toArray: Array[Any] = values
 
-  override def withLiteral(value: Any): Row = ArrayRow(values :+ value)
-  override def withValues(vs: Row): Row = ArrayRow(values ++ vs.toArray)
+  override def withValue(value: Any): Row = ArrayRow(values :+ value)
 
   override def selectIndices(indices: Int*): Row = ArrayRow(indices.toArray.map(values))
   override def dropIndex(index: Int): Row = ArrayRow(values.take(index) ++ values.drop(index + 1))
@@ -212,8 +190,7 @@ class SeqRow private(values: Seq[Any]) extends Row {
 
   override def selectIndices(indices: Int *): SeqRow = SeqRow(indices.map(index => values(realIndex(index))))
 
-  override def withLiteral(value: Any): Row = new SeqRow(value +: values)
-  override def withValues(vs: Row): Row = new SeqRow(vs.toSeq.reverse ++ values)
+  override def withValue(value: Any): Row = new SeqRow(value +: values)
 
   override def dropIndex(index: Int): Row = {
     val i = realIndex(index)

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -1,11 +1,14 @@
 package ml.combust.mleap.runtime
 
+import ml.combust.mleap.runtime.Row.RowSelector
 import ml.combust.mleap.runtime.function.UserDefinedFunction
 import org.apache.spark.ml.linalg.Vector
 
 /** Companion object for creating default rows.
   */
 object Row {
+  type RowSelector = (Row) => Any
+
   /** Create a row using the default implementation [[ArrayRow]].
     *
     * @param values values in the row
@@ -98,30 +101,30 @@ trait Row {
 
   /** Add value to row with a user defined function.
     *
-    * @param indices input indices to the udf
+    * @param selectors row selectors to generate inputs to function
     * @param udf user defined function to call
     * @return row with calculated value added
     */
-  def withValue(indices: Int *)(udf: UserDefinedFunction): Row = {
+  def withValue(selectors: RowSelector *)(udf: UserDefinedFunction): Row = {
     udf.inputs.length match {
       case 0 =>
         val f = udf.f.asInstanceOf[() => Any]
         withLiteral(f())
       case 1 =>
         val f = udf.f.asInstanceOf[(Any) => Any]
-        withLiteral(f(get(indices.head)))
+        withLiteral(f(selectors.head(this)))
       case 2 =>
         val f = udf.f.asInstanceOf[(Any, Any) => Any]
-        withLiteral(f(get(indices.head), get(indices(1))))
+        withLiteral(f(selectors.head(this), selectors(1)(this)))
       case 3 =>
         val f = udf.f.asInstanceOf[(Any, Any, Any) => Any]
-        withLiteral(f(get(indices.head), get(indices(1)), get(indices(2))))
+        withLiteral(f(selectors.head(this), selectors(1)(this), selectors(2)(this)))
       case 4 =>
         val f = udf.f.asInstanceOf[(Any, Any, Any, Any) => Any]
-        withLiteral(f(get(indices.head), get(indices(1)), get(indices(2)), get(indices(3))))
+        withLiteral(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this)))
       case 5 =>
         val f = udf.f.asInstanceOf[(Any, Any, Any, Any, Any) => Any]
-        withLiteral(f(get(indices.head), get(indices(1)), get(indices(2)), get(indices(3)), get(indices(4))))
+        withLiteral(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this), selectors(4)(this)))
     }
   }
 

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -1,5 +1,6 @@
 package ml.combust.mleap.runtime
 
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import org.apache.spark.ml.linalg.Vector
 
 /** Companion object for creating default rows.
@@ -87,6 +88,35 @@ trait Row {
     * @return seq of values from row
     */
   def toSeq: Seq[Any]
+
+  /** Add value to row with a user defined function.
+    *
+    * @param indices input indices to the udf
+    * @param udf user defined function to call
+    * @return row with calculated value added
+    */
+  def withValue(indices: Array[Int])(udf: UserDefinedFunction): Row = {
+    udf.inputs.length match {
+      case 0 =>
+        val f = udf.f.asInstanceOf[() => Any]
+        withValue(f())
+      case 1 =>
+        val f = udf.f.asInstanceOf[(Any) => Any]
+        withValue(f(get(indices.head)))
+      case 2 =>
+        val f = udf.f.asInstanceOf[(Any, Any) => Any]
+        withValue(f(get(indices.head), get(indices(1))))
+      case 3 =>
+        val f = udf.f.asInstanceOf[(Any, Any, Any) => Any]
+        withValue(f(get(indices.head), get(indices(1)), get(indices(2))))
+      case 4 =>
+        val f = udf.f.asInstanceOf[(Any, Any, Any, Any) => Any]
+        withValue(f(get(indices.head), get(indices(1)), get(indices(2)), get(indices(3))))
+      case 5 =>
+        val f = udf.f.asInstanceOf[(Any, Any, Any, Any, Any) => Any]
+        withValue(f(get(indices.head), get(indices(1)), get(indices(2)), get(indices(3)), get(indices(4))))
+    }
+  }
 
   /** Add a value to the row.
     *

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/Selector.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/Selector.scala
@@ -13,7 +13,7 @@ import scala.language.implicitConversions
   * and array selector.
   *
   * [[FieldSelector]] selects the value of a given field.
-  * [[MultipleFieldSelector]] creates an array from the values of a given set of fields.
+  * [[ArraySelector]] creates an array from the values of a given set of fields.
   */
 sealed trait Selector
 
@@ -29,12 +29,12 @@ object Selector {
     */
   implicit def apply(name: String): FieldSelector = FieldSelector(name)
 
-  /** Create an [[MultipleFieldSelector]] for a given list of names.
+  /** Create an [[ArraySelector]] for a given list of names.
     *
     * @param names fields names used to construct the array
     * @return array selector
     */
-  implicit def apply(names: Array[String]): MultipleFieldSelector = MultipleFieldSelector(names: _*)
+  implicit def apply(names: Array[String]): ArraySelector = ArraySelector(names: _*)
 }
 
 /** Class for a selector that extracts the value of a field from a [[ml.combust.mleap.runtime.Row]].
@@ -47,4 +47,4 @@ case class FieldSelector(field: String) extends Selector
   *
   * @param fields names of fields used to construct array
   */
-case class MultipleFieldSelector(fields: String *) extends Selector
+case class ArraySelector(fields: String *) extends Selector

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/Selector.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/Selector.scala
@@ -13,7 +13,7 @@ import scala.language.implicitConversions
   * and array selector.
   *
   * [[FieldSelector]] selects the value of a given field.
-  * [[ArraySelector]] creates an array from the values of a given set of fields.
+  * [[MultipleFieldSelector]] creates an array from the values of a given set of fields.
   */
 sealed trait Selector
 
@@ -29,12 +29,12 @@ object Selector {
     */
   implicit def apply(name: String): FieldSelector = FieldSelector(name)
 
-  /** Create an [[ArraySelector]] for a given list of names.
+  /** Create an [[MultipleFieldSelector]] for a given list of names.
     *
     * @param names fields names used to construct the array
     * @return array selector
     */
-  implicit def apply(names: Array[String]): ArraySelector = ArraySelector(names: _*)
+  implicit def apply(names: Array[String]): MultipleFieldSelector = MultipleFieldSelector(names: _*)
 }
 
 /** Class for a selector that extracts the value of a field from a [[ml.combust.mleap.runtime.Row]].
@@ -47,4 +47,4 @@ case class FieldSelector(field: String) extends Selector
   *
   * @param fields names of fields used to construct array
   */
-case class ArraySelector(fields: String *) extends Selector
+case class MultipleFieldSelector(fields: String *) extends Selector

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/Selector.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/Selector.scala
@@ -1,0 +1,50 @@
+package ml.combust.mleap.runtime.function
+
+import scala.language.implicitConversions
+
+/** Trait for a LeapFrame selector.
+  *
+  * A selector generates values based on other values found
+  * in a [[ml.combust.mleap.runtime.Row]]. The name parameters
+  * to a selector specifies which column of the row to get
+  * the values from.
+  *
+  * Currently there are two supported selectors: a field selector and
+  * and array selector.
+  *
+  * [[FieldSelector]] selects the value of a given field.
+  * [[ArraySelector]] creates an array from the values of a given set of fields.
+  */
+sealed trait Selector
+
+/** Companion object for selectors.
+  *
+  * Provides implicit conversions for convenience.
+  */
+object Selector {
+  /** Create a [[FieldSelector]] for a given name.
+    *
+    * @param name name of field
+    * @return field selector
+    */
+  implicit def apply(name: String): FieldSelector = FieldSelector(name)
+
+  /** Create an [[ArraySelector]] for a given list of names.
+    *
+    * @param names fields names used to construct the array
+    * @return array selector
+    */
+  implicit def apply(names: Array[String]): ArraySelector = ArraySelector(names: _*)
+}
+
+/** Class for a selector that extracts the value of a field from a [[ml.combust.mleap.runtime.Row]].
+  *
+  * @param field name of field to extract
+  */
+case class FieldSelector(field: String) extends Selector
+
+/** Class for a selector that constructs an array from values in a [[ml.combust.mleap.runtime.Row]].
+  *
+  * @param fields names of fields used to construct array
+  */
+case class ArraySelector(fields: String *) extends Selector

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
@@ -15,10 +15,18 @@ object UserDefinedFunction {
   }
   import universe._
 
-  implicit def apply[RT: TypeTag](f: () => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq())
-  implicit def apply[RT: TypeTag, T1: TypeTag](f: (T1) => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq(dataType[T1]))
-  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag](f: (T1, T2) => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2]))
-  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag, T3: TypeTag](f: (T1, T2, T3) => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3]))
+  implicit def apply[RT: TypeTag](f: () => RT): UserDefinedFunction =
+    UserDefinedFunction(f, dataType[RT], Seq())
+  implicit def apply[RT: TypeTag, T1: TypeTag](f: (T1) => RT): UserDefinedFunction =
+    UserDefinedFunction(f, dataType[RT], Seq(dataType[T1]))
+  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag](f: (T1, T2) => RT): UserDefinedFunction =
+    UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2]))
+  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag, T3: TypeTag](f: (T1, T2, T3) => RT): UserDefinedFunction =
+    UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3]))
+  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag, T3: TypeTag, T4: TypeTag](f: (T1, T2, T3, T4) => RT): UserDefinedFunction =
+    UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3], dataType[T4]))
+  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag, T3: TypeTag, T4: TypeTag, T5: TypeTag](f: (T1, T2, T3, T4, T5) => RT): UserDefinedFunction =
+    UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3], dataType[T4], dataType[T5]))
 
   private def dataType[T: TypeTag]: DataType = dataTypeFor(mirrorType[T])
   private def dataTypeFor(tpe: `Type`): DataType = synchronized {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
@@ -1,0 +1,45 @@
+package ml.combust.mleap.runtime.function
+
+import ml.combust.mleap.runtime.types._
+import org.apache.spark.ml.linalg.Vector
+
+import scala.language.implicitConversions
+
+/**
+  * Created by hollinwilkins on 10/19/16.
+  */
+object UserDefinedFunction {
+  val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+  def mirror: universe.Mirror = synchronized {
+    universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
+  }
+  import universe._
+
+  implicit def apply[RT: TypeTag](f: () => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq())
+  implicit def apply[RT: TypeTag, T1: TypeTag](f: (T1) => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq(dataType[T1]))
+  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag](f: (T1, T2) => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2]))
+  implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag, T3: TypeTag](f: (T1, T2, T3) => RT): UserDefinedFunction = UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3]))
+
+  private def dataType[T: TypeTag]: DataType = dataTypeFor(mirrorType[T])
+  private def dataTypeFor(tpe: `Type`): DataType = synchronized {
+    tpe match {
+      case t if t <:< mirrorType[Boolean] => BooleanType
+      case t if t <:< mirrorType[String] => StringType
+      case t if t <:< mirrorType[Long] => LongType
+      case t if t <:< mirrorType[Double] => DoubleType
+      case t if t <:< mirrorType[Array[_]] =>
+        val TypeRef(_, _, Seq(elementType)) = t
+        val baseType = dataTypeFor(elementType)
+        ListType(baseType)
+      case t if t <:< mirrorType[Vector] => TensorType.doubleVector()
+      case t if t <:< mirrorType[Any] => AnyType
+      case t => throw new IllegalArgumentException(s"unknown type $t")
+    }
+  }
+
+  private def mirrorType[T: TypeTag]: `Type` = typeTag[T].in(mirror).tpe.normalize
+}
+
+case class UserDefinedFunction(f: AnyRef,
+                               returnType: DataType,
+                               inputs: Seq[DataType])

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
@@ -5,8 +5,7 @@ import ml.combust.mleap.runtime.types._
 import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
 
-/**
-  * Created by hollinwilkins on 10/19/16.
+/** Companion object for creating user defined functions.
   */
 object UserDefinedFunction {
   import ml.combust.mleap.runtime.reflection.MleapReflection.dataType

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
@@ -1,19 +1,15 @@
 package ml.combust.mleap.runtime.function
 
 import ml.combust.mleap.runtime.types._
-import org.apache.spark.ml.linalg.Vector
 
 import scala.language.implicitConversions
+import scala.reflect.runtime.universe.TypeTag
 
 /**
   * Created by hollinwilkins on 10/19/16.
   */
 object UserDefinedFunction {
-  val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
-  def mirror: universe.Mirror = synchronized {
-    universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
-  }
-  import universe._
+  import ml.combust.mleap.runtime.reflection.MleapReflection.dataType
 
   implicit def apply[RT: TypeTag](f: () => RT): UserDefinedFunction =
     UserDefinedFunction(f, dataType[RT], Seq())
@@ -27,26 +23,6 @@ object UserDefinedFunction {
     UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3], dataType[T4]))
   implicit def apply[RT: TypeTag, T1: TypeTag, T2: TypeTag, T3: TypeTag, T4: TypeTag, T5: TypeTag](f: (T1, T2, T3, T4, T5) => RT): UserDefinedFunction =
     UserDefinedFunction(f, dataType[RT], Seq(dataType[T1], dataType[T2], dataType[T3], dataType[T4], dataType[T5]))
-
-  private def dataType[T: TypeTag]: DataType = dataTypeFor(mirrorType[T])
-  private def dataTypeFor(tpe: `Type`): DataType = synchronized {
-    tpe match {
-      case t if t <:< mirrorType[Boolean] => BooleanType
-      case t if t <:< mirrorType[String] => StringType
-      case t if t <:< mirrorType[Int] => IntegerType
-      case t if t <:< mirrorType[Long] => LongType
-      case t if t <:< mirrorType[Double] => DoubleType
-      case t if t <:< mirrorType[Array[_]] =>
-        val TypeRef(_, _, Seq(elementType)) = t
-        val baseType = dataTypeFor(elementType)
-        ListType(baseType)
-      case t if t <:< mirrorType[Vector] => TensorType.doubleVector()
-      case t if t <:< mirrorType[Any] => AnyType
-      case t => throw new IllegalArgumentException(s"unknown type $t")
-    }
-  }
-
-  private def mirrorType[T: TypeTag]: `Type` = typeTag[T].in(mirror).tpe.normalize
 }
 
 case class UserDefinedFunction(f: AnyRef,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/function/UserDefinedFunction.scala
@@ -33,6 +33,7 @@ object UserDefinedFunction {
     tpe match {
       case t if t <:< mirrorType[Boolean] => BooleanType
       case t if t <:< mirrorType[String] => StringType
+      case t if t <:< mirrorType[Int] => IntegerType
       case t if t <:< mirrorType[Long] => LongType
       case t if t <:< mirrorType[Double] => DoubleType
       case t if t <:< mirrorType[Array[_]] =>

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/reflection/MleapReflection.scala
@@ -1,0 +1,43 @@
+package ml.combust.mleap.runtime.reflection
+
+import ml.combust.mleap.runtime.types._
+import org.apache.spark.ml.linalg.Vector
+
+/**
+  * Created by hollinwilkins on 10/21/16.
+  */
+object MleapReflectionLock
+
+trait MleapReflection {
+  val universe: scala.reflect.runtime.universe.type
+  def mirror: universe.Mirror
+
+  import universe._
+
+  def dataType[T: TypeTag]: DataType = dataTypeFor(mirrorType[T])
+  private def dataTypeFor(tpe: `Type`): DataType = MleapReflectionLock.synchronized {
+    tpe match {
+      case t if t <:< mirrorType[Boolean] => BooleanType
+      case t if t <:< mirrorType[String] => StringType
+      case t if t <:< mirrorType[Int] => IntegerType
+      case t if t <:< mirrorType[Long] => LongType
+      case t if t <:< mirrorType[Double] => DoubleType
+      case t if t <:< mirrorType[Array[_]] =>
+        val TypeRef(_, _, Seq(elementType)) = t
+        val baseType = dataTypeFor(elementType)
+        ListType(baseType)
+      case t if t <:< mirrorType[Vector] => TensorType.doubleVector()
+      case t if t =:= mirrorType[Any] => AnyType
+      case t => throw new IllegalArgumentException(s"unknown type $t")
+    }
+  }
+
+  private def mirrorType[T: TypeTag]: `Type` = typeTag[T].in(mirror).tpe.normalize
+}
+
+object MleapReflection extends MleapReflection {
+  override val universe: scala.reflect.runtime.universe.type = scala.reflect.runtime.universe
+  override def mirror: universe.Mirror = MleapReflectionLock.synchronized {
+    universe.runtimeMirror(Thread.currentThread().getContextClassLoader)
+  }
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/Transformer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/Transformer.scala
@@ -2,6 +2,7 @@ package ml.combust.mleap.runtime.transformer
 
 import java.util.UUID
 
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
 
 import scala.util.Try
@@ -31,4 +32,14 @@ trait Transformer {
     * @return try new builder with transformation applied
     */
   def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB]
+}
+
+trait FeatureTransformer extends Transformer {
+  val inputCol: String
+  val outputCol: String
+  val exec: UserDefinedFunction
+
+  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
+    builder.withOutput(outputCol, inputCol)(exec)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
@@ -1,15 +1,18 @@
 package ml.combust.mleap.runtime.transformer.builder
 
-import ml.combust.mleap.runtime.types.{AnyType, DataType, StructField}
-import ml.combust.mleap.runtime.Row
-import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.function.{Selector, UserDefinedFunction}
 
-import scala.util.{Failure, Try}
+import scala.util.Try
 
 /**
   * Created by hwilkins on 11/15/15.
   */
 trait TransformBuilder[B <: TransformBuilder[B]] extends Serializable {
-  def withOutput(name: String, inputs: String *)
-                (f: UserDefinedFunction): Try[B]
+  def withOutput(name: String, selectors: Selector *)
+                (udf: UserDefinedFunction): Try[B]
+
+  def withOutput(name: String, input: String, inputs: String *)
+                (udf: UserDefinedFunction): Try[B] = {
+    withOutput(name: String, Selector(input) +: inputs.map(Selector.apply): _*)(udf)
+  }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
@@ -10,14 +10,6 @@ import scala.util.{Failure, Try}
   * Created by hwilkins on 11/15/15.
   */
 trait TransformBuilder[B <: TransformBuilder[B]] extends Serializable {
-  def withInput(name: String): Try[(B, Int)] = withInput(name, AnyType)
-  def withInput(name: String, dataType: DataType): Try[(B, Int)]
-  def withInputs(fields: Seq[(String, DataType)]): Try[(B, Seq[Int])]
-
-  def withOutput(name: String, fields: String *)
+  def withOutput(name: String, inputs: String *)
                 (f: UserDefinedFunction): Try[B]
-  def withOutput(name: String, dataType: DataType)
-                (o: (Row) => Any): Try[B]
-  def withOutputs(fields: Seq[StructField])
-                 (o: (Row) => Row): Try[B]
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
@@ -1,7 +1,8 @@
 package ml.combust.mleap.runtime.transformer.builder
 
-import ml.combust.mleap.runtime.types.{DataType, StructField}
+import ml.combust.mleap.runtime.types.{AnyType, DataType, StructField}
 import ml.combust.mleap.runtime.Row
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 
 import scala.util.{Failure, Try}
 
@@ -9,9 +10,12 @@ import scala.util.{Failure, Try}
   * Created by hwilkins on 11/15/15.
   */
 trait TransformBuilder[B <: TransformBuilder[B]] extends Serializable {
-  def withInput(name: String): Try[(B, Int)]
+  def withInput(name: String): Try[(B, Int)] = withInput(name, AnyType)
   def withInput(name: String, dataType: DataType): Try[(B, Int)]
+  def withInputs(fields: Seq[(String, DataType)]): Try[(B, Seq[Int])]
 
+  def withOutput(name: String, fields: String *)
+                (f: UserDefinedFunction): Try[B]
   def withOutput(name: String, dataType: DataType)
                 (o: (Row) => Any): Try[B]
   def withOutputs(fields: Seq[StructField])

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Try}
 trait TransformBuilder[B <: TransformBuilder[B]] extends Serializable {
   def withInput(name: String): Try[(B, Int)] = withInput(name, AnyType)
   def withInput(name: String, dataType: DataType): Try[(B, Int)]
-  def withInputs(fields: Seq[(String, DataType)]): Try[(B, Seq[Int])]
+  def withInputs(fields: Seq[(String, DataType)]): Try[(B, Array[Int])]
 
   def withOutput(name: String, fields: String *)
                 (f: UserDefinedFunction): Try[B]

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/TransformBuilder.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Try}
 trait TransformBuilder[B <: TransformBuilder[B]] extends Serializable {
   def withInput(name: String): Try[(B, Int)] = withInput(name, AnyType)
   def withInput(name: String, dataType: DataType): Try[(B, Int)]
-  def withInputs(fields: Seq[(String, DataType)]): Try[(B, Array[Int])]
+  def withInputs(fields: Seq[(String, DataType)]): Try[(B, Seq[Int])]
 
   def withOutput(name: String, fields: String *)
                 (f: UserDefinedFunction): Try[B]

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/DecisionTreeClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/DecisionTreeClassifier.scala
@@ -1,23 +1,23 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.DecisionTreeClassifierModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by hollinwilkins on 3/30/16.
   */
-case class DecisionTreeClassifier(uid: String = Transformer.uniqueName("decision_tree_classification"),
+case class DecisionTreeClassifier(override val uid: String = Transformer.uniqueName("decision_tree_classification"),
                                   featuresCol: String,
                                   predictionCol: String,
                                   model: DecisionTreeClassifierModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case (b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/GBTClassifier.scala
@@ -1,10 +1,10 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.GBTClassifierModel
-import ml.combust.mleap.runtime.Row
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, StructField, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -15,10 +15,9 @@ case class GBTClassifier(override val uid: String = Transformer.uniqueName("gbt_
                          featuresCol: String,
                          predictionCol: String,
                          model: GBTClassifierModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case(b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegression.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegression.scala
@@ -1,35 +1,32 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.LogisticRegressionModel
-import ml.combust.mleap.runtime.Row
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, StructField, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by hwilkins on 10/22/15.
   */
-case class LogisticRegression(uid: String = Transformer.uniqueName("logistic_regression"),
+case class LogisticRegression(override val uid: String = Transformer.uniqueName("logistic_regression"),
                               featuresCol: String,
                               predictionCol: String,
                               probabilityCol: Option[String] = None,
                               model: LogisticRegressionModel) extends Transformer {
+  val predictProbability: UserDefinedFunction = (features: Vector) => model.predictProbability(features)
+  val probabilityToPrediction: UserDefinedFunction = (probability: Double) => model.probabilityToPrediction(probability)
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case(b, featuresIndex) =>
-        probabilityCol match {
-          case Some(probability) =>
-            b.withOutputs(Seq(StructField(predictionCol, DoubleType),
-              StructField(probability, DoubleType))) {
-              row =>
-                val (prediction, probability) = model.predictWithProbability(row.getVector(featuresIndex))
-                Row(prediction, probability)
-            }
-          case None =>
-            b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-        }
+    probabilityCol match {
+      case Some(p) =>
+        for(b <- builder.withOutput(p, featuresCol)(predictProbability);
+            b2 <- b.withOutput(predictionCol, p)(probabilityToPrediction)) yield b2
+      case None =>
+        builder.withOutput(predictionCol, featuresCol)(exec)
     }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/OneVsRest.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/OneVsRest.scala
@@ -1,35 +1,31 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.OneVsRestModel
-import ml.combust.mleap.runtime.Row
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, StructField, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by hwilkins on 10/22/15.
   */
-case class OneVsRest(uid: String = Transformer.uniqueName("one_vs_rest"),
+case class OneVsRest(override val uid: String = Transformer.uniqueName("one_vs_rest"),
                      featuresCol: String,
                      predictionCol: String,
                      probabilityCol: Option[String] = None,
                      model: OneVsRestModel) extends Transformer {
+  val predictProbability: UserDefinedFunction = (features: Vector) => model.predictProbability(features)
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case(b, featuresIndex) =>
-        probabilityCol match {
-          case Some(pc) =>
-            b.withOutputs(Seq(StructField(predictionCol, DoubleType),
-              StructField(pc, DoubleType))) {
-              row =>
-                val (prediction, probability) = model.predictWithProbability(row.getVector(featuresIndex))
-                Row(prediction, probability)
-            }
-          case None =>
-            b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-        }
+    probabilityCol match {
+      case Some(p) =>
+        for(b <- builder.withOutput(p, featuresCol)(predictProbability);
+            b2 <- b.withOutput(predictionCol, featuresCol)(exec)) yield b2
+      case None =>
+        builder.withOutput(predictionCol, featuresCol)(exec)
     }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/RandomForestClassifier.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/RandomForestClassifier.scala
@@ -1,23 +1,23 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.RandomForestClassifierModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by hollinwilkins on 3/30/16.
   */
-case class RandomForestClassifier(uid: String = Transformer.uniqueName("random_forest_classification"),
+case class RandomForestClassifier(override val uid: String = Transformer.uniqueName("random_forest_classification"),
                                   featuresCol: String,
                                   predictionCol: String,
                                   model: RandomForestClassifierModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case (b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/SupportVectorMachine.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/classification/SupportVectorMachine.scala
@@ -1,23 +1,32 @@
 package ml.combust.mleap.runtime.transformer.classification
 
 import ml.combust.mleap.core.classification.SupportVectorMachineModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by hollinwilkins on 4/14/16.
   */
-case class SupportVectorMachine(uid: String = Transformer.uniqueName("support_vector_machine"),
+case class SupportVectorMachine(override val uid: String = Transformer.uniqueName("support_vector_machine"),
                                 featuresCol: String,
                                 predictionCol: String,
+                                probabilityCol: Option[String] = None,
                                 model: SupportVectorMachineModel) extends Transformer {
+  val predictProbability: UserDefinedFunction = (features: Vector) => model.predictProbability(features)
+  val probabilityToPrediction: UserDefinedFunction = (probability: Double) => model.probabilityToPrediction(probability)
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case(b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
+    probabilityCol match {
+      case Some(p) =>
+        for(b <- builder.withOutput(p, featuresCol)(predictProbability);
+            b2 <- b.withOutput(predictionCol, p)(probabilityToPrediction)) yield b2
+      case None =>
+        builder.withOutput(predictionCol, featuresCol)(exec)
     }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/clustering/KMeans.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/clustering/KMeans.scala
@@ -1,9 +1,10 @@
 package ml.combust.mleap.runtime.transformer.clustering
 
 import ml.combust.mleap.core.clustering.KMeansModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -14,10 +15,9 @@ case class KMeans(override val uid: String = Transformer.uniqueName("k_means"),
                   featuresCol: String,
                   predictionCol: String,
                   model: KMeansModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case(b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)).toDouble)
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Bucketizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Bucketizer.scala
@@ -1,23 +1,15 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.BucketizerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.DoubleType
-
-import scala.util.Try
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 /**
   * Created by mikhail on 9/19/16.
   */
-case class Bucketizer(uid: String = Transformer.uniqueName("bucketizer"),
-                      inputCol: String,
-                      outputCol: String,
-                      model: BucketizerModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, DoubleType).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, DoubleType)(row => model(row.getDouble(inputIndex)))
-    }
-  }
+case class Bucketizer(override val uid: String = Transformer.uniqueName("bucketizer"),
+                      override val inputCol: String,
+                      override val outputCol: String,
+                      model: BucketizerModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Double) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/ElementwiseProduct.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/ElementwiseProduct.scala
@@ -1,23 +1,19 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.ElementwiseProductModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by mikhail on 9/23/16.
   */
-case class ElementwiseProduct(uid: String = Transformer.uniqueName("elmentwise_product"),
-                              inputCol: String,
-                              outputCol: String,
-                              model: ElementwiseProductModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
-    }
-  }
+case class ElementwiseProduct(override val uid: String = Transformer.uniqueName("elmentwise_product"),
+                              override val inputCol: String,
+                              override val  outputCol: String,
+                              model: ElementwiseProductModel) extends FeatureTransformer {
+
+  override val exec: UserDefinedFunction = (value: Vector) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/HashingTermFrequency.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/HashingTermFrequency.scala
@@ -1,23 +1,17 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.HashingTermFrequencyModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{StringType, TensorType}
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 import scala.util.Try
 
 /**
   * Created by hwilkins on 12/30/15.
   */
-case class HashingTermFrequency(uid: String = Transformer.uniqueName("hashing_term_frequency"),
-                                inputCol: String,
-                                outputCol: String,
-                                hashingTermFrequency: HashingTermFrequencyModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, StringType).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => hashingTermFrequency(row.getString(inputIndex)))
-    }
-  }
+case class HashingTermFrequency(override val uid: String = Transformer.uniqueName("hashing_term_frequency"),
+                                override val inputCol: String,
+                                override val outputCol: String,
+                                model: HashingTermFrequencyModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: String) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MaxAbsScaler.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MaxAbsScaler.scala
@@ -1,23 +1,19 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.MaxAbsScalerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by mikhail on 9/18/16.
   */
-case class MaxAbsScaler(uid: String = Transformer.uniqueName("max_abs_scaler"),
-                       inputCol: String,
-                       outputCol: String,
-                       model: MaxAbsScalerModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
-    }
-  }
+case class MaxAbsScaler(override val uid: String = Transformer.uniqueName("max_abs_scaler"),
+                        override val inputCol: String,
+                        override val outputCol: String,
+                       model: MaxAbsScalerModel) extends FeatureTransformer {
+
+  override val exec: UserDefinedFunction = (value: Vector) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MinMaxScaler.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MinMaxScaler.scala
@@ -1,23 +1,16 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.MinMaxScalerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
-
-import scala.util.Try
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+import org.apache.spark.ml.linalg.Vector
 
 /**
   * Created by mikhail on 9/18/16.
   */
-case class MinMaxScaler(uid: String = Transformer.uniqueName("min_max_scaler"),
-                       inputCol: String,
-                       outputCol: String,
-                       model: MinMaxScalerModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
-    }
-  }
+case class MinMaxScaler(override val uid: String = Transformer.uniqueName("min_max_scaler"),
+                        override val inputCol: String,
+                        override val outputCol: String,
+                        model: MinMaxScalerModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Vector) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/NGram.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/NGram.scala
@@ -1,23 +1,15 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.NGramModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{ListType, StringType}
-
-import scala.util.Try
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 /**
   * Created by mikhail on 10/16/16.
   */
-case class NGram(uid: String = Transformer.uniqueName("ngram"),
-                 inputCol: String,
-                 outputCol: String,
-                 model: NGramModel) extends Transformer{
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, ListType(StringType)).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, ListType(StringType))(row => model(row.getArray(inputIndex)))
-    }
-  }
+case class NGram(override val uid: String = Transformer.uniqueName("ngram"),
+                 override val inputCol: String,
+                 override val outputCol: String,
+                 model: NGramModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Array[String]) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Normalizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Normalizer.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.NormalizerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -11,13 +11,8 @@ import scala.util.Try
   * Created by hollinwilkins on 9/24/16.
   */
 case class Normalizer(override val uid: String = Transformer.uniqueName("normalizer"),
-                      inputCol: String,
-                      outputCol: String,
-                      model: NormalizerModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
-    }
-  }
+                      override val inputCol: String,
+                      override val outputCol: String,
+                      model: NormalizerModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Vector) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/OneHotEncoder.scala
@@ -1,23 +1,17 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.OneHotEncoderModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 import scala.util.Try
 
 /**
   * Created by hollinwilkins on 5/10/16.
   */
-case class OneHotEncoder(uid: String = Transformer.uniqueName("one_hot_encoder"),
-                         inputCol: String,
-                         outputCol: String,
-                         model: OneHotEncoderModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, DoubleType).flatMap {
-      case(b, index) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getDouble(index)))
-    }
-  }
+case class OneHotEncoder(override val uid: String = Transformer.uniqueName("one_hot_encoder"),
+                         override val inputCol: String,
+                         override val outputCol: String,
+                         model: OneHotEncoderModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Double) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Pca.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Pca.scala
@@ -1,9 +1,9 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.PcaModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -11,13 +11,8 @@ import scala.util.Try
   * Created by hollinwilkins on 10/12/16.
   */
 case class Pca(override val uid: String = Transformer.uniqueName("pca"),
-               inputCol: String,
-               outputCol: String,
-               model: PcaModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
-    }
-  }
+               override val inputCol: String,
+               override val outputCol: String,
+               model: PcaModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Vector) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/ReverseStringIndexer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/ReverseStringIndexer.scala
@@ -1,23 +1,15 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.ReverseStringIndexerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.StringType
-
-import scala.util.Try
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 /**
   * Created by hollinwilkins on 3/30/16.
   */
-case class ReverseStringIndexer(uid: String = Transformer.uniqueName("reverse_string_indexer"),
-                                inputCol: String,
-                                outputCol: String,
-                                model: ReverseStringIndexerModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, StringType)(row => model(row.getDouble(inputIndex).toInt))
-    }
-  }
+case class ReverseStringIndexer(override val uid: String = Transformer.uniqueName("reverse_string_indexer"),
+                                override val inputCol: String,
+                                override val outputCol: String,
+                                model: ReverseStringIndexerModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Double) => model(value.toInt)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StandardScaler.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StandardScaler.scala
@@ -1,23 +1,18 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.StandardScalerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
 /**
   * Created by hwilkins on 10/23/15.
   */
-case class StandardScaler(uid: String = Transformer.uniqueName("standard_scaler"),
-                          inputCol: String,
-                          outputCol: String,
-                          model: StandardScalerModel) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, TensorType.doubleVector()).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => model(row.getVector(inputIndex)))
-    }
-  }
+case class StandardScaler(override val uid: String = Transformer.uniqueName("standard_scaler"),
+                          override val inputCol: String,
+                          override val outputCol: String,
+                          model: StandardScalerModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: Vector) => model(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
@@ -1,6 +1,7 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.StringIndexerModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
 import ml.combust.mleap.runtime.types.DoubleType
@@ -14,11 +15,10 @@ case class StringIndexer(uid: String = Transformer.uniqueName("string_indexer"),
                          inputCol: String,
                          outputCol: String,
                          model: StringIndexerModel) extends Transformer {
+  val exec: UserDefinedFunction = (value: Any) => model(value.toString)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, DoubleType)(row => model(row.get(inputIndex).toString))
-    }
+    builder.withOutput(outputCol, inputCol)(exec)
   }
 
   def toReverse: ReverseStringIndexer = ReverseStringIndexer(inputCol = inputCol,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/StringIndexer.scala
@@ -2,24 +2,16 @@ package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.StringIndexerModel
 import ml.combust.mleap.runtime.function.UserDefinedFunction
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.DoubleType
-
-import scala.util.Try
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 /**
   * Created by hwilkins on 10/22/15.
   */
-case class StringIndexer(uid: String = Transformer.uniqueName("string_indexer"),
-                         inputCol: String,
-                         outputCol: String,
-                         model: StringIndexerModel) extends Transformer {
+case class StringIndexer(override val uid: String = Transformer.uniqueName("string_indexer"),
+                         override val inputCol: String,
+                         override val outputCol: String,
+                         model: StringIndexerModel) extends FeatureTransformer {
   val exec: UserDefinedFunction = (value: Any) => model(value.toString)
-
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withOutput(outputCol, inputCol)(exec)
-  }
 
   def toReverse: ReverseStringIndexer = ReverseStringIndexer(inputCol = inputCol,
     outputCol = outputCol,

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Tokenizer.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/Tokenizer.scala
@@ -1,22 +1,14 @@
 package ml.combust.mleap.runtime.transformer.feature
 
 import ml.combust.mleap.core.feature.TokenizerModel
-import ml.combust.mleap.runtime.transformer.Transformer
-import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{ListType, StringType}
-
-import scala.util.Try
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
 
 /**
   * Created by hwilkins on 12/30/15.
   */
-case class Tokenizer(uid: String = Transformer.uniqueName("tokenizer"),
-                     inputCol: String,
-                     outputCol: String) extends Transformer {
-  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(inputCol, StringType).flatMap {
-      case (b, inputIndex) =>
-        b.withOutput(outputCol, ListType(StringType))(row => TokenizerModel.defaultTokenizer(row.getString(inputIndex)))
-    }
-  }
+case class Tokenizer(override val uid: String = Transformer.uniqueName("tokenizer"),
+                     override val inputCol: String,
+                     override val outputCol: String) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (value: String) => TokenizerModel.defaultTokenizer(value)
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssembler.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssembler.scala
@@ -12,10 +12,10 @@ import scala.util.Try
 case class VectorAssembler(override val uid: String = Transformer.uniqueName("vector_assembler"),
                            inputCols: Array[String],
                            outputCol: String) extends Transformer {
-  private val assembler: VectorAssemblerModel = VectorAssemblerModel.default
-
+  val exec = (values: Array[Any]) => VectorAssemblerModel.default(values)
 
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
+    builder.withOutput(outputCol, inputCols)(exec)
 //    inputCols.foldLeft(Try((builder, Seq[Int]()))) {
 //      (result, col) => result.flatMap {
 //        case (b, indices) =>
@@ -28,6 +28,5 @@ case class VectorAssembler(override val uid: String = Transformer.uniqueName("ve
 //      case (b, indices) =>
 //        b.withOutput(outputCol, TensorType.doubleVector())(row => assembler(indices.map(row.get): _*))
 //    }
-    Try(builder)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssembler.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssembler.scala
@@ -3,30 +3,31 @@ package ml.combust.mleap.runtime.transformer.feature
 import ml.combust.mleap.core.feature.VectorAssemblerModel
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.TensorType
 
 import scala.util.Try
 
 /**
   * Created by hwilkins on 10/23/15.
   */
-case class VectorAssembler(uid: String = Transformer.uniqueName("vector_assembler"),
+case class VectorAssembler(override val uid: String = Transformer.uniqueName("vector_assembler"),
                            inputCols: Array[String],
                            outputCol: String) extends Transformer {
   private val assembler: VectorAssemblerModel = VectorAssemblerModel.default
 
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    inputCols.foldLeft(Try((builder, Seq[Int]()))) {
-      (result, col) => result.flatMap {
-        case (b, indices) =>
-          b.withInput(col)
-            .map {
-              case (b3, index) => (b3, indices :+ index)
-            }
-      }
-    }.flatMap {
-      case (b, indices) =>
-        b.withOutput(outputCol, TensorType.doubleVector())(row => assembler(indices.map(row.get): _*))
-    }
+//    inputCols.foldLeft(Try((builder, Seq[Int]()))) {
+//      (result, col) => result.flatMap {
+//        case (b, indices) =>
+//          b.withInput(col)
+//            .map {
+//              case (b3, index) => (b3, indices :+ index)
+//            }
+//      }
+//    }.flatMap {
+//      case (b, indices) =>
+//        b.withOutput(outputCol, TensorType.doubleVector())(row => assembler(indices.map(row.get): _*))
+//    }
+    Try(builder)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegression.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/DecisionTreeRegression.scala
@@ -1,9 +1,10 @@
 package ml.combust.mleap.runtime.transformer.regression
 
 import ml.combust.mleap.core.regression.DecisionTreeRegressionModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -14,10 +15,9 @@ case class DecisionTreeRegression(uid: String = Transformer.uniqueName("decision
                                   featuresCol: String,
                                   predictionCol: String,
                                   model: DecisionTreeRegressionModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case (b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/GBTRegression.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/GBTRegression.scala
@@ -1,9 +1,10 @@
 package ml.combust.mleap.runtime.transformer.regression
 
 import ml.combust.mleap.core.regression.GBTRegressionModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -14,10 +15,9 @@ case class GBTRegression(override val uid: String = Transformer.uniqueName("gbt_
                          featuresCol: String,
                          predictionCol: String,
                          model: GBTRegressionModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case (b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/LinearRegression.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/LinearRegression.scala
@@ -1,9 +1,10 @@
 package ml.combust.mleap.runtime.transformer.regression
 
 import ml.combust.mleap.core.regression.LinearRegressionModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -18,10 +19,9 @@ case class LinearRegression(uid: String = Transformer.uniqueName("linear_regress
                             featuresCol: String,
                             predictionCol: String,
                             model: LinearRegressionModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case(b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/RandomForestRegression.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/regression/RandomForestRegression.scala
@@ -1,9 +1,10 @@
 package ml.combust.mleap.runtime.transformer.regression
 
 import ml.combust.mleap.core.regression.RandomForestRegressionModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import ml.combust.mleap.runtime.transformer.Transformer
 import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
-import ml.combust.mleap.runtime.types.{DoubleType, TensorType}
+import org.apache.spark.ml.linalg.Vector
 
 import scala.util.Try
 
@@ -14,10 +15,9 @@ case class RandomForestRegression(uid: String = Transformer.uniqueName("random_f
                                   featuresCol: String,
                                   predictionCol: String,
                                   model: RandomForestRegressionModel) extends Transformer {
+  val exec: UserDefinedFunction = (features: Vector) => model(features)
+
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
-    builder.withInput(featuresCol, TensorType.doubleVector()).flatMap {
-      case (b, featuresIndex) =>
-        b.withOutput(predictionCol, DoubleType)(row => model(row.getVector(featuresIndex)))
-    }
+    builder.withOutput(predictionCol, featuresCol)(exec)
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
@@ -9,6 +9,7 @@ object AnyType extends BasicType {
   override def fits(other: DataType): Boolean = true
 }
 
+object IntegerType extends BasicType
 object LongType extends BasicType
 object BooleanType extends BasicType
 object DoubleType extends BasicType

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/types/DataType.scala
@@ -1,17 +1,19 @@
 package ml.combust.mleap.runtime.types
 
-/**
- * Created by hwilkins on 10/23/15.
- */
 sealed trait DataType extends Serializable {
   def fits(other: DataType): Boolean = this == other
 }
 sealed trait BasicType extends DataType with Serializable
 
+object AnyType extends BasicType {
+  override def fits(other: DataType): Boolean = true
+}
+
 object LongType extends BasicType
 object BooleanType extends BasicType
 object DoubleType extends BasicType
 object StringType extends BasicType
+
 case class TensorType(base: BasicType, dimensions: Seq[Int]) extends DataType {
   override def fits(other: DataType): Boolean = {
     if(super.fits(other)) { return true }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
@@ -38,15 +38,6 @@ trait DatasetSpec[D <: Dataset] extends FunSpec {
         }
       }
 
-      describe("#withValues") {
-        it("creates a new dataset with additional values in every row") {
-          val dataset2 = dataset.withValues(r => Row(s"${r.getString(1)}:${r.getInt(0)}", 78 + r.getInt(0)))
-          val data = dataset2.toArray.map(r => (r.getString(2), r.getInt(3)))
-
-          assert(data sameElements Array(("hey:42", 120), ("there:13", 91)))
-        }
-      }
-
       describe("#selectIndices") {
         it("creates a new dataset with the selected indices") {
           val dataset2 = dataset.selectIndices(0)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
@@ -28,20 +28,13 @@ trait DatasetSpec[D <: Dataset] extends FunSpec {
       describe("#withValue") {
         describe("with a user defined function") {
           it("created a new dataset with the calculated value from the user defined function") {
-            val dataset2 = dataset.withValue(1, 0) {
+            val dataset2 = dataset.withValue(r => r.get(1), r => r.get(0)) {
               (v1: String, v2: Int) => s"$v1:$v2"
             }
             val data = dataset2.toArray.map(r => r.getString(2))
 
             assert(data sameElements Array("hey:42", "there:13"))
           }
-        }
-
-        it("creates a new dataset with a calculated value in every row") {
-          val dataset2 = dataset.withValue(r => s"${r.getString(1)}:${r.getInt(0)}")
-          val data = dataset2.toArray.map(r => r.getString(2))
-
-          assert(data sameElements Array("hey:42", "there:13"))
         }
       }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/DatasetSpec.scala
@@ -26,6 +26,17 @@ trait DatasetSpec[D <: Dataset] extends FunSpec {
       }
 
       describe("#withValue") {
+        describe("with a user defined function") {
+          it("created a new dataset with the calculated value from the user defined function") {
+            val dataset2 = dataset.withValue(1, 0) {
+              (v1: String, v2: Int) => s"$v1:$v2"
+            }
+            val data = dataset2.toArray.map(r => r.getString(2))
+
+            assert(data sameElements Array("hey:42", "there:13"))
+          }
+        }
+
         it("creates a new dataset with a calculated value in every row") {
           val dataset2 = dataset.withValue(r => s"${r.getString(1)}:${r.getInt(0)}")
           val data = dataset2.toArray.map(r => r.getString(2))

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
@@ -69,36 +69,6 @@ trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
         }
       }
 
-      describe("#withFields") {
-        it("creates a new LeapFrame with multiple fields added") {
-          val newFields = Seq(StructField("test_string_2", StringType),
-            StructField("test_double_2", DoubleType))
-          val frame2 = frame.withFields(newFields) {
-            r => Row(s"${r.getString(0)}:77", r.getDouble(1) + 20)
-          }.get
-
-          val data = frame2.dataset.toArray
-
-          assert(frame2.schema.fields.length == 4)
-          assert(frame2.schema.indexOf("test_string_2").get == 2)
-          assert(frame2.schema.indexOf("test_double_2").get == 3)
-          assert(data(0).toArray sameElements Array("hello", 42.13, "hello:77", 62.13))
-          assert(data(1).toArray sameElements Array("there", 13.42, "there:77", 33.42))
-        }
-
-        describe("with already existing fields") {
-          it("returns a failure") {
-            val newFields = Seq(StructField("test_string", StringType),
-              StructField("test_double", DoubleType))
-            val frame2 = frame.withFields(newFields) {
-              r => Row(s"${r.getString(0)}:77", r.getDouble(1) + 20)
-            }
-
-            assert(frame2.isFailure)
-          }
-        }
-      }
-
       describe("#dropField") {
         it("creates a new LeapFrame with field dropped") {
           val frame2 = frame.dropField("test_string").get

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
@@ -46,6 +46,30 @@ trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
       }
 
       describe("#withField") {
+        describe("with a user defined function") {
+          it("creates a new LeapFrame with field added") {
+            val frame2 = frame.withField("test_double_2", "test_double") {
+              (r: Double) => r + 10
+            }.get
+            val data = frame2.dataset.toArray
+
+            assert(frame2.schema.fields.length == 3)
+            assert(frame2.schema.indexOf("test_double_2").get == 2)
+            assert(data(0).getDouble(2) == 52.13)
+            assert(data(1).getDouble(2) == 23.42)
+          }
+
+          describe("with non-matching data types") {
+            it("returns a failure") {
+              val frame2 = frame.withField("test_double_2", "test_double") {
+                (r: Int) => r + 10
+              }
+
+              assert(frame2.isFailure)
+            }
+          }
+        }
+
         it("creates a new LeapFrame with field added") {
           val frame2 = frame.withField("test_double_2", DoubleType)(r => r.getDouble(1) + 10).get
           val data = frame2.dataset.toArray

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
@@ -46,32 +46,10 @@ trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
       }
 
       describe("#withField") {
-        describe("with a user defined function") {
-          it("creates a new LeapFrame with field added") {
-            val frame2 = frame.withField("test_double_2", "test_double") {
-              (r: Double) => r + 10
-            }.get
-            val data = frame2.dataset.toArray
-
-            assert(frame2.schema.fields.length == 3)
-            assert(frame2.schema.indexOf("test_double_2").get == 2)
-            assert(data(0).getDouble(2) == 52.13)
-            assert(data(1).getDouble(2) == 23.42)
-          }
-
-          describe("with non-matching data types") {
-            it("returns a failure") {
-              val frame2 = frame.withField("test_double_2", "test_double") {
-                (r: Int) => r + 10
-              }
-
-              assert(frame2.isFailure)
-            }
-          }
-        }
-
         it("creates a new LeapFrame with field added") {
-          val frame2 = frame.withField("test_double_2", DoubleType)(r => r.getDouble(1) + 10).get
+          val frame2 = frame.withField("test_double_2", "test_double") {
+            (r: Double) => r + 10
+          }.get
           val data = frame2.dataset.toArray
 
           assert(frame2.schema.fields.length == 3)
@@ -80,8 +58,14 @@ trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
           assert(data(1).getDouble(2) == 23.42)
         }
 
-        describe("with already existing field") {
-          it("returns a Failure") { assert(frame.withField("test_double", DoubleType)(r => 56.3).isFailure) }
+        describe("with non-matching data types") {
+          it("returns a failure") {
+            val frame2 = frame.withField("test_double_2", "test_double") {
+              (r: Int) => r + 10
+            }
+
+            assert(frame2.isFailure)
+          }
         }
       }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/LeapFrameSpec.scala
@@ -67,6 +67,14 @@ trait LeapFrameSpec[LF <: LeapFrame[LF]] extends FunSpec {
             assert(frame2.isFailure)
           }
         }
+
+        describe("with MultipleFieldSelector and non Array[Any] data type") {
+          val frame2 = frame.withField("test_double_2", Array("test_double")) {
+            (r: Array[Double]) => r.head
+          }
+
+          assert(frame2.isFailure)
+        }
       }
 
       describe("#dropField") {

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
@@ -97,7 +97,7 @@ trait RowSpec[R <: Row] extends FunSpec {
     describe("#withValue") {
       describe("user defined function") {
         it("adds a value using a user defined function") {
-          val r2 = row.withValue(1, 2) {
+          val r2 = row.withValue(r => r.get(1), r => r.get(2)) {
             (v1: Int, v2: Array[Int]) => v1 + v2(0)
           }
 

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
@@ -1,6 +1,5 @@
 package ml.combust.mleap.runtime
 
-import ml.combust.mleap.runtime.function.UserDefinedFunction
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSpec
 
@@ -105,49 +104,11 @@ trait RowSpec[R <: Row] extends FunSpec {
         }
       }
 
-      describe("function arg") {
-        it("adds a value using a function") {
-          val adder = (r: Row) => r.getInt(1) + r.getArray[Int](2)(0)
-          val r2 = row.withValue(adder)
-
-          assert(r2.getInt(6) == 98)
-        }
-      }
-
       describe("value arg") {
         it("adds the value to the row") {
-          val r = row.withLiteral(789)
+          val r = row.withValue(789)
 
           assert(r.getInt(6) == 789)
-        }
-      }
-    }
-
-    describe("#withValues") {
-      describe("function arg") {
-        it("adds the row result to this row") {
-          val multiAdder = {
-            (r: Row) =>
-              val a = r.getInt(1)
-              val ar = r.getArray[Int](2)
-              Row(ar.map(_ + a): _*)
-          }
-          val r = row.withValues(multiAdder)
-
-          assert(r.getInt(6) == 98)
-          assert(r.getInt(7) == 120)
-          assert(r.getInt(8) == 65)
-        }
-      }
-
-      describe("row arg") {
-        it("adds the row to this row") {
-          val r = Row(44, 55, 66)
-          val r2 = row.withValues(r)
-
-          assert(r2.getInt(6) == 44)
-          assert(r2.getInt(7) == 55)
-          assert(r2.getInt(8) == 66)
         }
       }
     }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/RowSpec.scala
@@ -1,5 +1,6 @@
 package ml.combust.mleap.runtime
 
+import ml.combust.mleap.runtime.function.UserDefinedFunction
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSpec
 
@@ -10,147 +11,161 @@ import org.scalatest.FunSpec
 trait RowSpec[R <: Row] extends FunSpec {
   def create(values: Any *): R
 
-  def row(name: String): Unit = {
-    describe(name) {
-      val rowValues = Seq("test", 42, Array(56, 78, 23), 57.3, Vectors.dense(Array(2.3, 4.4)))
-      val row = create(rowValues: _*)
+  def row(): Unit = {
+    val rowValues = Seq("test", 42, Array(56, 78, 23), 57.3, Vectors.dense(Array(2.3, 4.4)), 56L)
+    val row = create(rowValues: _*)
 
-      describe("#apply") {
-        it("gets the value at a given index") {
-          assert(row(0) == "test")
-          assert(row(1) == 42)
-          assert(row(2).asInstanceOf[Array[Int]] sameElements Array(56, 78, 23))
-        }
+    describe("#apply") {
+      it("gets the value at a given index") {
+        assert(row(0) == "test")
+        assert(row(1) == 42)
+        assert(row(2).asInstanceOf[Array[Int]] sameElements Array(56, 78, 23))
       }
+    }
 
-      describe("#get") {
-        it("gets the value at a given index") {
-          assert(row.get(0) == "test")
-          assert(row.get(1) == 42)
-          assert(row.get(2).asInstanceOf[Array[Int]] sameElements Array(56, 78, 23))
-        }
+    describe("#get") {
+      it("gets the value at a given index") {
+        assert(row.get(0) == "test")
+        assert(row.get(1) == 42)
+        assert(row.get(2).asInstanceOf[Array[Int]] sameElements Array(56, 78, 23))
       }
+    }
 
-      describe("#getAs") {
-        it("gets the value at a given index and casts it") {
-          assert(row.getAs[String](0) == "test")
-          assert(row.getAs[Int](1) == 42)
-          assert(row.getAs[Array[Int]](2) sameElements Array(56, 78, 23))
-        }
+    describe("#getAs") {
+      it("gets the value at a given index and casts it") {
+        assert(row.getAs[String](0) == "test")
+        assert(row.getAs[Int](1) == 42)
+        assert(row.getAs[Array[Int]](2) sameElements Array(56, 78, 23))
       }
+    }
 
-      describe("#getDouble") {
-        it("gets the value at a given index as a double") {
-          assert(row.getDouble(3) == 57.3)
-        }
+    describe("#getDouble") {
+      it("gets the value at a given index as a double") {
+        assert(row.getDouble(3) == 57.3)
       }
+    }
 
-      describe("#getInt") {
-        it("gets the value at a given index as an int") {
-          assert(row.getInt(1) == 42)
-        }
+    describe("#getInt") {
+      it("gets the value at a given index as an int") {
+        assert(row.getInt(1) == 42)
       }
+    }
 
-      describe("#getString") {
-        it("gets the value at a given index as a string") {
-          assert(row.getString(0) == "test")
-        }
+    describe("#getLong") {
+      it("gets the value at a given index as a long") {
+        assert(row.getLong(5) == 56)
       }
+    }
 
-      describe("#getVector") {
-        it("gets the value at a given index as a vector") {
-          val vec = row.getVector(4)
-
-          assert(vec(0) == 2.3)
-          assert(vec(1) == 4.4)
-        }
+    describe("#getString") {
+      it("gets the value at a given index as a string") {
+        assert(row.getString(0) == "test")
       }
+    }
 
-      describe("#getArray") {
-        it("gets the value at a given index as an array") {
-          val arr = row.getArray[Int](2)
+    describe("#getVector") {
+      it("gets the value at a given index as a vector") {
+        val vec = row.getVector(4)
 
-          assert(arr(0) == 56)
-          assert(arr(1) == 78)
-          assert(arr(2) == 23)
-        }
+        assert(vec(0) == 2.3)
+        assert(vec(1) == 4.4)
       }
+    }
 
-      describe("#toArray") {
-        it("gets all the values as an array") {
-          assert(row.toArray sameElements rowValues)
-        }
+    describe("#getArray") {
+      it("gets the value at a given index as an array") {
+        val arr = row.getArray[Int](2)
+
+        assert(arr(0) == 56)
+        assert(arr(1) == 78)
+        assert(arr(2) == 23)
       }
+    }
 
-      describe("#toSeq") {
-        it("gets all the values as a seq") {
-          assert(row.toSeq == rowValues)
-        }
+    describe("#toArray") {
+      it("gets all the values as an array") {
+        assert(row.toArray sameElements rowValues)
       }
+    }
 
-      describe("#withValue") {
-        describe("function arg") {
-          it("adds a value using a function") {
-            val adder = (r: Row) => r.getInt(1) + r.getArray[Int](2)(0)
-            val r2 = row.withValue(adder)
+    describe("#toSeq") {
+      it("gets all the values as a seq") {
+        assert(row.toSeq == rowValues)
+      }
+    }
 
-            assert(r2.getInt(5) == 98)
+    describe("#withValue") {
+      describe("user defined function") {
+        it("adds a value using a user defined function") {
+          val r2 = row.withValue(1, 2) {
+            (v1: Int, v2: Array[Int]) => v1 + v2(0)
           }
-        }
 
-        describe("value arg") {
-          it("adds the value to the row") {
-            val r = row.withValue(789)
-
-            assert(r.getInt(5) == 789)
-          }
+          assert(r2.getInt(6) == 98)
         }
       }
 
-      describe("#withValues") {
-        describe("function arg") {
-          it("adds the row result to this row") {
-            val multiAdder = {
-              (r: Row) =>
-                val a = r.getInt(1)
-                val ar = r.getArray[Int](2)
-                Row(ar.map(_ + a): _*)
-            }
-            val r = row.withValues(multiAdder)
+      describe("function arg") {
+        it("adds a value using a function") {
+          val adder = (r: Row) => r.getInt(1) + r.getArray[Int](2)(0)
+          val r2 = row.withValue(adder)
 
-            assert(r.getInt(5) == 98)
-            assert(r.getInt(6) == 120)
-            assert(r.getInt(7) == 65)
-          }
-        }
-
-        describe("row arg") {
-          it("adds the row to this row") {
-            val r = Row(44, 55, 66)
-            val r2 = row.withValues(r)
-
-            assert(r2.getInt(5) == 44)
-            assert(r2.getInt(6) == 55)
-            assert(r2.getInt(7) == 66)
-          }
+          assert(r2.getInt(6) == 98)
         }
       }
 
-      describe("#selectIndices") {
-        it("creates a new row from the selected indices") {
-          val r = row.selectIndices(3, 0)
+      describe("value arg") {
+        it("adds the value to the row") {
+          val r = row.withLiteral(789)
 
-          assert(r.getDouble(0) == 57.3)
-          assert(r.getString(1) == "test")
+          assert(r.getInt(6) == 789)
+        }
+      }
+    }
+
+    describe("#withValues") {
+      describe("function arg") {
+        it("adds the row result to this row") {
+          val multiAdder = {
+            (r: Row) =>
+              val a = r.getInt(1)
+              val ar = r.getArray[Int](2)
+              Row(ar.map(_ + a): _*)
+          }
+          val r = row.withValues(multiAdder)
+
+          assert(r.getInt(6) == 98)
+          assert(r.getInt(7) == 120)
+          assert(r.getInt(8) == 65)
         }
       }
 
-      describe("#dropIndex") {
-        it("drops the value at an index") {
-          val r = row.dropIndex(2).dropIndex(3)
+      describe("row arg") {
+        it("adds the row to this row") {
+          val r = Row(44, 55, 66)
+          val r2 = row.withValues(r)
 
-          assert(r.toArray sameElements Array("test", 42, 57.3))
+          assert(r2.getInt(6) == 44)
+          assert(r2.getInt(7) == 55)
+          assert(r2.getInt(8) == 66)
         }
+      }
+    }
+
+    describe("#selectIndices") {
+      it("creates a new row from the selected indices") {
+        val r = row.selectIndices(3, 0)
+
+        assert(r.getDouble(0) == 57.3)
+        assert(r.getString(1) == "test")
+      }
+    }
+
+    describe("#dropIndex") {
+      it("drops the value at an index") {
+        val r = row.dropIndex(2).dropIndex(3)
+
+        assert(r.toArray sameElements Array("test", 42, 57.3, 56L))
       }
     }
   }
@@ -159,11 +174,11 @@ trait RowSpec[R <: Row] extends FunSpec {
 class ArrayRowSpec extends RowSpec[ArrayRow] {
   override def create(values: Any*): ArrayRow = ArrayRow(values.toArray)
 
-  it should behave like row("ArrayRow")
+  it should behave like row()
 }
 
 class SeqRowSpec extends RowSpec[SeqRow] {
   override def create(values: Any*): SeqRow = SeqRow(values)
 
-  it should behave like row("SeqRow")
+  it should behave like row()
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
@@ -12,7 +12,7 @@ class SelectorSpec extends FunSpec {
       val arraySelector: Selector = Array("hey", "there")
 
       assert(fieldSelector == FieldSelector("hey"))
-      assert(arraySelector == ArraySelector("hey", "there"))
+      assert(arraySelector == MultipleFieldSelector("hey", "there"))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
@@ -12,7 +12,7 @@ class SelectorSpec extends FunSpec {
       val arraySelector: Selector = Array("hey", "there")
 
       assert(fieldSelector == FieldSelector("hey"))
-      assert(arraySelector == MultipleFieldSelector("hey", "there"))
+      assert(arraySelector == ArraySelector("hey", "there"))
     }
   }
 }

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/SelectorSpec.scala
@@ -1,0 +1,18 @@
+package ml.combust.mleap.runtime.function
+
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 10/22/16.
+  */
+class SelectorSpec extends FunSpec {
+  describe("#applye") {
+    it("creates selectors implicitly") {
+      val fieldSelector: Selector = "hey"
+      val arraySelector: Selector = Array("hey", "there")
+
+      assert(fieldSelector == FieldSelector("hey"))
+      assert(arraySelector == ArraySelector("hey", "there"))
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/function/UserDefinedFunctionSpec.scala
@@ -1,0 +1,36 @@
+package ml.combust.mleap.runtime.function
+
+import ml.combust.mleap.runtime.types._
+import org.apache.spark.ml.linalg.Vector
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 10/21/16.
+  */
+class UserDefinedFunctionSpec extends FunSpec {
+  describe("#apply") {
+    it("creates the udf") {
+      val udf0: UserDefinedFunction = () => "hello"
+      val udf1: UserDefinedFunction = (v1: Double) => Array("hello")
+      val udf2: UserDefinedFunction = (v1: Long, v2: Int) => v1 + v2
+      val udf3: UserDefinedFunction = (v1: Boolean, v2: Vector) => "hello": Any
+      val udf4: UserDefinedFunction = (v1: Array[Boolean], v2: Array[String], v3: Array[Double]) => "hello"
+      val udf5: UserDefinedFunction = (v1: Double, v2: Double, v3: Double, v4: Double, v5: String) => 55d
+
+      assertUdfForm(udf0, StringType)
+      assertUdfForm(udf1, ListType(StringType), DoubleType)
+      assertUdfForm(udf2, LongType, LongType, IntegerType)
+      assertUdfForm(udf3, AnyType, BooleanType, TensorType.doubleVector())
+      assertUdfForm(udf4, StringType, ListType(BooleanType), ListType(StringType), ListType(DoubleType))
+      assertUdfForm(udf5, DoubleType, DoubleType, DoubleType, DoubleType, DoubleType, StringType)
+    }
+  }
+
+  private def assertUdfForm(udf: UserDefinedFunction, returnType: DataType, argTypes: DataType *): Unit = {
+    assert(udf.returnType == returnType)
+    assert(udf.inputs.length == argTypes.length)
+    udf.inputs.zip(argTypes).foreach {
+      case (inputType, argType) => assert(inputType == argType)
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
@@ -1,0 +1,42 @@
+package ml.combust.mleap.runtime.reflection
+
+import ml.combust.mleap.runtime.types._
+import org.apache.spark.ml.linalg.Vector
+import org.scalatest.FunSpec
+
+import scala.util.Try
+
+/**
+  * Created by hollinwilkins on 10/21/16.
+  */
+class MleapReflectionSpec extends FunSpec {
+  describe("#dataType") {
+    import MleapReflection.dataType
+
+    it("returns the Mleap runtime data type from the Scala type") {
+      assert(dataType[Boolean] == BooleanType)
+      assert(dataType[String] == StringType)
+      assert(dataType[Int] == IntegerType)
+      assert(dataType[Long] == LongType)
+      assert(dataType[Double] == DoubleType)
+      assert(dataType[Array[Boolean]] == ListType(BooleanType))
+      assert(dataType[Array[String]] == ListType(StringType))
+      assert(dataType[Array[Int]] == ListType(IntegerType))
+      assert(dataType[Array[Long]] == ListType(LongType))
+      assert(dataType[Array[Double]] == ListType(DoubleType))
+      assert(dataType[Array[Array[Boolean]]] == ListType(ListType(BooleanType)))
+      assert(dataType[Array[Array[String]]] == ListType(ListType(StringType)))
+      assert(dataType[Array[Array[Int]]] == ListType(ListType(IntegerType)))
+      assert(dataType[Array[Array[Long]]] == ListType(ListType(LongType)))
+      assert(dataType[Array[Array[Double]]] == ListType(ListType(DoubleType)))
+      assert(dataType[Vector] == TensorType.doubleVector())
+      assert(dataType[Any] == AnyType)
+    }
+
+    describe("#with an invalid Scala type") {
+      it("throws an illegal argument exception") {
+        assertThrows[IllegalArgumentException] { dataType[FunSpec] }
+      }
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/reflection/MleapReflectionSpec.scala
@@ -4,8 +4,6 @@ import ml.combust.mleap.runtime.types._
 import org.apache.spark.ml.linalg.Vector
 import org.scalatest.FunSpec
 
-import scala.util.Try
-
 /**
   * Created by hollinwilkins on 10/21/16.
   */

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegressionSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/classification/LogisticRegressionSpec.scala
@@ -33,8 +33,8 @@ class LogisticRegressionSpec extends FunSpec {
 
         it("executes the logistic regression model and outputs the prediction/probability") {
           val frame2 = logisticRegression2.transform(frame).get
-          val prediction = frame2.dataset.toArray(0).getDouble(1)
-          val probability = frame2.dataset.toArray(0).getDouble(2)
+          val probability = frame2.dataset.toArray(0).getDouble(1)
+          val prediction = frame2.dataset.toArray(0).getDouble(2)
 
           assert(prediction == 1.0)
           assert(probability > 0.84)

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssemblerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssemblerSpec.scala
@@ -1,34 +1,34 @@
-//package ml.combust.mleap.runtime.transformer.feature
-//
-//import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
-//import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType, TensorType}
-//import org.apache.spark.ml.linalg.Vectors
-//import org.scalatest.FunSpec
-//
-///**
-//  * Created by hollinwilkins on 9/15/16.
-//  */
-//class VectorAssemblerSpec extends FunSpec {
-//  val schema = StructType(Seq(StructField("feature1", TensorType.doubleVector()),
-//    StructField("feature2", DoubleType),
-//    StructField("feature3", DoubleType))).get
-//  val dataset = LocalDataset(Array(Row(Vectors.dense(Array(0.5, -0.5, 1.0)), 42.0, 13.0)))
-//  val frame = LeapFrame(schema, dataset)
-//  val vectorAssembler = VectorAssembler(inputCols = Array("feature1", "feature2", "feature3"),
-//    outputCol = "features")
-//
-//  describe("#transform") {
-//    it("assembles its inputs into a new vector") {
-//      val frame2 = vectorAssembler.transform(frame).get
-//      val data = frame2.dataset.toArray
-//
-//      assert(data(0).getVector(3).toArray sameElements Array(0.5, -0.5, 1.0, 42.0, 13.0))
-//    }
-//
-//    describe("with invalid input") {
-//      val vectorAssembler2 = vectorAssembler.copy(inputCols = vectorAssembler.inputCols :+ "bad_feature")
-//
-//      it("returns a Failure") { assert(vectorAssembler2.transform(frame).isFailure) }
-//    }
-//  }
-//}
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
+import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType, TensorType}
+import org.apache.spark.ml.linalg.Vectors
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 9/15/16.
+  */
+class VectorAssemblerSpec extends FunSpec {
+  val schema = StructType(Seq(StructField("feature1", TensorType.doubleVector()),
+    StructField("feature2", DoubleType),
+    StructField("feature3", DoubleType))).get
+  val dataset = LocalDataset(Array(Row(Vectors.dense(Array(0.5, -0.5, 1.0)), 42.0, 13.0)))
+  val frame = LeapFrame(schema, dataset)
+  val vectorAssembler = VectorAssembler(inputCols = Array("feature1", "feature2", "feature3"),
+    outputCol = "features")
+
+  describe("#transform") {
+    it("assembles its inputs into a new vector") {
+      val frame2 = vectorAssembler.transform(frame).get
+      val data = frame2.dataset.toArray
+
+      assert(data(0).getVector(3).toArray sameElements Array(0.5, -0.5, 1.0, 42.0, 13.0))
+    }
+
+    describe("with invalid input") {
+      val vectorAssembler2 = vectorAssembler.copy(inputCols = vectorAssembler.inputCols :+ "bad_feature")
+
+      it("returns a Failure") { assert(vectorAssembler2.transform(frame).isFailure) }
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssemblerSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/VectorAssemblerSpec.scala
@@ -1,34 +1,34 @@
-package ml.combust.mleap.runtime.transformer.feature
-
-import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
-import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType, TensorType}
-import org.apache.spark.ml.linalg.Vectors
-import org.scalatest.FunSpec
-
-/**
-  * Created by hollinwilkins on 9/15/16.
-  */
-class VectorAssemblerSpec extends FunSpec {
-  val schema = StructType(Seq(StructField("feature1", TensorType.doubleVector()),
-    StructField("feature2", DoubleType),
-    StructField("feature3", DoubleType))).get
-  val dataset = LocalDataset(Array(Row(Vectors.dense(Array(0.5, -0.5, 1.0)), 42.0, 13.0)))
-  val frame = LeapFrame(schema, dataset)
-  val vectorAssembler = VectorAssembler(inputCols = Array("feature1", "feature2", "feature3"),
-    outputCol = "features")
-
-  describe("#transform") {
-    it("assembles its inputs into a new vector") {
-      val frame2 = vectorAssembler.transform(frame).get
-      val data = frame2.dataset.toArray
-
-      assert(data(0).getVector(3).toArray sameElements Array(0.5, -0.5, 1.0, 42.0, 13.0))
-    }
-
-    describe("with invalid input") {
-      val vectorAssembler2 = vectorAssembler.copy(inputCols = vectorAssembler.inputCols :+ "bad_feature")
-
-      it("returns a Failure") { assert(vectorAssembler2.transform(frame).isFailure) }
-    }
-  }
-}
+//package ml.combust.mleap.runtime.transformer.feature
+//
+//import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
+//import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType, TensorType}
+//import org.apache.spark.ml.linalg.Vectors
+//import org.scalatest.FunSpec
+//
+///**
+//  * Created by hollinwilkins on 9/15/16.
+//  */
+//class VectorAssemblerSpec extends FunSpec {
+//  val schema = StructType(Seq(StructField("feature1", TensorType.doubleVector()),
+//    StructField("feature2", DoubleType),
+//    StructField("feature3", DoubleType))).get
+//  val dataset = LocalDataset(Array(Row(Vectors.dense(Array(0.5, -0.5, 1.0)), 42.0, 13.0)))
+//  val frame = LeapFrame(schema, dataset)
+//  val vectorAssembler = VectorAssembler(inputCols = Array("feature1", "feature2", "feature3"),
+//    outputCol = "features")
+//
+//  describe("#transform") {
+//    it("assembles its inputs into a new vector") {
+//      val frame2 = vectorAssembler.transform(frame).get
+//      val data = frame2.dataset.toArray
+//
+//      assert(data(0).getVector(3).toArray sameElements Array(0.5, -0.5, 1.0, 42.0, 13.0))
+//    }
+//
+//    describe("with invalid input") {
+//      val vectorAssembler2 = vectorAssembler.copy(inputCols = vectorAssembler.inputCols :+ "bad_feature")
+//
+//      it("returns a Failure") { assert(vectorAssembler2.transform(frame).isFailure) }
+//    }
+//  }
+//}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,11 @@ object Dependencies {
 
   lazy val mleapCoreDependencies = baseDependencies.union(sparkLocalDependencies)
 
-  lazy val mleapRuntimeDependencies = baseDependencies.union(sparkLocalDependencies)
+  def mleapRuntimeDependencies(scalaVersion: String) = {
+    baseDependencies.
+      union(sparkLocalDependencies).
+      union(Seq("org.scala-lang" % "scala-reflect" % scalaVersion))
+  }
 
   lazy val mleapSparkDependencies = baseDependencies
     .union(sparkDependencies)


### PR DESCRIPTION
This is part of a larger effort to be able to execute on Spark easier. This will also simplify how we write transformers eventually.

User defined functions use implicits and reflection to allow users to write Scala functions that can operate on data within a LeapFrame.

This is for ticket #9 