### PR TITLE
Implement RowTransformBuilder for transforming single rows.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 MLeap
-Copyright 2016 Combust.ML, inc.
+Copyright 2016 Combust, inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/MleapContext.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/MleapContext.scala
@@ -20,7 +20,9 @@ object MleapContext {
 
 case class MleapContext private (hr: HasBundleRegistry,
                                  customTypes: Map[String, CustomType],
-                                 customTypeAliases: Map[String, CustomType]) {
+                                 customTypeAliases: Map[String, CustomType]) extends HasBundleRegistry {
+  override def bundleRegistry: BundleRegistry = hr.bundleRegistry
+
   def withCustomType[T](customType: CustomType): MleapContext = {
     copy(customTypes = customTypes + (customType.klazz.getCanonicalName -> customType),
       customTypeAliases = customTypeAliases + (customType.name -> customType))

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/Row.scala
@@ -106,25 +106,23 @@ trait Row {
     * @return row with calculated value added
     */
   def withValue(selectors: RowSelector *)(udf: UserDefinedFunction): Row = {
+    withValue(udfValue(selectors: _*)(udf))
+  }
+
+  def udfValue(selectors: RowSelector *)(udf: UserDefinedFunction): Any = {
     udf.inputs.length match {
       case 0 =>
-        val f = udf.f.asInstanceOf[() => Any]
-        withValue(f())
+        udf.f.asInstanceOf[() => Any]()
       case 1 =>
-        val f = udf.f.asInstanceOf[(Any) => Any]
-        withValue(f(selectors.head(this)))
+        udf.f.asInstanceOf[(Any) => Any](selectors.head(this))
       case 2 =>
-        val f = udf.f.asInstanceOf[(Any, Any) => Any]
-        withValue(f(selectors.head(this), selectors(1)(this)))
+        udf.f.asInstanceOf[(Any, Any) => Any](selectors.head(this), selectors(1)(this))
       case 3 =>
-        val f = udf.f.asInstanceOf[(Any, Any, Any) => Any]
-        withValue(f(selectors.head(this), selectors(1)(this), selectors(2)(this)))
+        udf.f.asInstanceOf[(Any, Any, Any) => Any](selectors.head(this), selectors(1)(this), selectors(2)(this))
       case 4 =>
-        val f = udf.f.asInstanceOf[(Any, Any, Any, Any) => Any]
-        withValue(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this)))
+        udf.f.asInstanceOf[(Any, Any, Any, Any) => Any](selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this))
       case 5 =>
-        val f = udf.f.asInstanceOf[(Any, Any, Any, Any, Any) => Any]
-        withValue(f(selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this), selectors(4)(this)))
+        udf.f.asInstanceOf[(Any, Any, Any, Any, Any) => Any](selectors.head(this), selectors(1)(this), selectors(2)(this), selectors(3)(this), selectors(4)(this))
     }
   }
 
@@ -170,6 +168,11 @@ case class ArrayRow(values: Array[Any]) extends Row {
 
   override def selectIndices(indices: Int*): Row = ArrayRow(indices.toArray.map(values))
   override def dropIndex(index: Int): Row = ArrayRow(values.take(index) ++ values.drop(index + 1))
+
+  def set(index: Int, value: Any): ArrayRow = {
+    values(index) = value
+    this
+  }
 }
 
 /** Companion object for creating a SeqRow.

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/RowUtil.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/RowUtil.scala
@@ -1,0 +1,57 @@
+package ml.combust.mleap.runtime
+
+import ml.combust.mleap.runtime.Row.RowSelector
+import ml.combust.mleap.runtime.function.{ArraySelector, FieldSelector, Selector}
+import ml.combust.mleap.runtime.types.{AnyType, DataType, ListType, StructType}
+
+import scala.util.{Failure, Try}
+
+/**
+  * Created by hollinwilkins on 10/30/16.
+  */
+object RowUtil {
+  def createRowSelectors(schema: StructType,
+                         inputs: Seq[DataType],
+                         selectors: Selector *): Try[Seq[RowSelector]] = {
+    var i = 0
+    selectors.foldLeft(Try(Seq[RowSelector]())) {
+      case (trss, s) =>
+        val rs = RowUtil.createRowSelector(schema, s, inputs(i)).flatMap {
+          rs => trss.map(trs => rs +: trs)
+        }
+        i = i + 1
+        rs
+    }
+  }
+
+  /** Create a row selector from a frame selector.
+    *
+    * @param schema schema for creating selectors
+    * @param selector frame selector
+    * @param dataType output data type of selector
+    * @return row selector
+    */
+  def createRowSelector(schema: StructType,
+                        selector: Selector,
+                        dataType: DataType): Try[RowSelector] = selector match {
+    case FieldSelector(name) =>
+      schema.indexedField(name).flatMap {
+        case (index, field) =>
+          if (dataType.fits(field.dataType)) {
+            Try(r => r.get(index))
+          } else {
+            Failure(new IllegalArgumentException(s"field $name data type ${field.dataType} does not match $dataType"))
+          }
+      }
+    case ArraySelector(fields@_*) =>
+      if (dataType == ListType(AnyType)) {
+        schema.indicesOf(fields: _*).map {
+          indices =>
+            val indicesArr = indices.toArray
+            r => indicesArr.map(r.get)
+        }
+      } else {
+        Failure(new IllegalArgumentException(s"multiple field selector must be an Array[Any], found $dataType"))
+      }
+  }
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilder.scala
@@ -1,0 +1,50 @@
+package ml.combust.mleap.runtime.transformer.builder
+
+import ml.combust.mleap.runtime.{ArrayRow, Row, RowUtil}
+import ml.combust.mleap.runtime.Row._
+import ml.combust.mleap.runtime.function.{ArraySelector, FieldSelector, Selector, UserDefinedFunction}
+import ml.combust.mleap.runtime.types.{AnyType, DataType, ListType, StructType}
+
+import scala.util.{Failure, Try}
+
+/**
+  * Created by hollinwilkins on 10/30/16.
+  */
+object RowTransformBuilder {
+  def apply(schema: StructType): RowTransformBuilder = RowTransformBuilder(schema, schema, Array())
+}
+
+case class RowTransformBuilder private (inputSchema: StructType,
+                                        outputSchema: StructType,
+                                        transforms: Array[(ArrayRow) => ArrayRow]) extends TransformBuilder[RowTransformBuilder] {
+  def arraySize: Int = outputSchema.fields.length
+
+  override def withOutput(name: String, selectors: Selector *)
+                         (udf: UserDefinedFunction): Try[RowTransformBuilder] = {
+    val index = outputSchema.fields.length
+
+    RowUtil.createRowSelectors(outputSchema, udf.inputs, selectors: _*).flatMap {
+      rowSelectors =>
+        outputSchema.withField(name, udf.returnType).map {
+          schema2 =>
+            val transform = (row: ArrayRow) => row.set(index, row.udfValue(rowSelectors: _*)(udf))
+            copy(outputSchema = schema2, transforms = transforms :+ transform)
+        }
+    }
+  }
+
+  /** Transform an input row with the predetermined schema.
+    *
+    * @param row row to transform
+    * @return transformed row
+    */
+  def transform(row: Row): ArrayRow = {
+    val arr = new Array[Any](arraySize)
+    row.toArray.copyToArray(arr)
+    val arrRow = ArrayRow(arr)
+
+    transforms.foldLeft(arrRow) {
+      (r, transform) => transform(r)
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilderSpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/builder/RowTransformBuilderSpec.scala
@@ -1,0 +1,38 @@
+package ml.combust.mleap.runtime.transformer.builder
+
+import ml.combust.mleap.core.regression.LinearRegressionModel
+import ml.combust.mleap.runtime.transformer.Pipeline
+import ml.combust.mleap.runtime.transformer.feature.VectorAssembler
+import ml.combust.mleap.runtime.transformer.regression.LinearRegression
+import ml.combust.mleap.runtime.Row
+import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType}
+import org.apache.spark.ml.linalg.Vectors
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 10/30/16.
+  */
+class RowTransformBuilderSpec extends FunSpec {
+  val schema = StructType(Seq(StructField("feature1", DoubleType),
+    StructField("feature2", DoubleType),
+    StructField("feature3", DoubleType))).get
+  val assembler = VectorAssembler(inputCols = Array("feature1", "feature2", "feature3"),
+    outputCol = "features")
+  val linearRegression = LinearRegression(featuresCol = "features",
+    predictionCol = "prediction",
+    model = LinearRegressionModel(coefficients = Vectors.dense(Array(1.0, 0.5, 5.0)),
+      intercept = 73.0))
+  val pipeline = Pipeline(transformers = Seq(assembler, linearRegression))
+
+  describe("building a transformer pipeline") {
+    it("transforms single rows at a time") {
+      val builder = RowTransformBuilder(schema)
+      val transformer = pipeline.transform(builder).get
+      val row1 = transformer.transform(Row(20.0, 10.0, 5.0))
+      val row2 = transformer.transform(Row(5.0, 17.0, 9.0))
+
+      assert(row1.toArray sameElements Array(20.0, 10.0, 5.0, Vectors.dense(Array(20.0, 10.0, 5.0)), 123.0))
+      assert(row2.toArray sameElements Array(5.0, 17.0, 9.0, Vectors.dense(Array(5.0, 17.0, 9.0)), 131.5))
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,10 +5,11 @@ object Dependencies {
 
   lazy val baseDependencies = Seq("org.scalatest" %% "scalatest" % "3.0.0" % "test")
 
-  lazy val sparkLocalDependencies = Seq("org.apache.spark" %% "spark-mllib-local" % sparkVersion % "provided")
+  lazy val sparkLocalDependencies = Seq("org.apache.spark" %% "spark-mllib-local" % sparkVersion)
   lazy val sparkDependencies = Seq("org.apache.spark" %% "spark-core" % sparkVersion,
     "org.apache.spark" %% "spark-sql" % sparkVersion,
     "org.apache.spark" %% "spark-mllib" % sparkVersion,
+    "org.apache.spark" %% "spark-mllib-local" % sparkVersion,
     "org.apache.spark" %% "spark-catalyst" % sparkVersion).map(_ % "provided")
 
   lazy val mleapCoreDependencies = baseDependencies.union(sparkLocalDependencies)


### PR DESCRIPTION
This transform builder allows us to generate very efficient transform pipelines because they:
1. Do not have to generate new schemas at every step
2. Need to create 1 array to store the final result