### PR TITLE
Fix Spark BigDecimal inputs.

### DIFF
--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorAssemblerModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/VectorAssemblerModel.scala
@@ -44,6 +44,13 @@ case class VectorAssemblerModel() extends Serializable {
           }
         }
         cur += vec.size
+      case v: java.math.BigDecimal =>
+        val d = v.doubleValue()
+        if (d != 0.0) {
+          indices += cur
+          values += d
+        }
+        cur += 1
     }
     Vectors.sparse(cur, indices.result(), values.result()).compressed
   }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/VectorAssemblerModelSpec.scala
@@ -1,5 +1,7 @@
 package ml.combust.mleap.core.feature
 
+import java.math.BigDecimal
+
 import org.apache.spark.ml.linalg.Vectors
 import org.scalatest.FunSpec
 
@@ -13,7 +15,7 @@ class VectorAssemblerModelSpec extends FunSpec {
       val expectedArray = Array(45.0, 76.8, 23.0, 45.6, 0.0, 22.3, 45.6, 0.0, 99.3)
 
       assert(assembler(Array(45.0,
-        76.8,
+        new BigDecimal(76.8),
         Vectors.dense(Array(23.0, 45.6)),
         Vectors.sparse(5, Array(1, 2, 4), Array(22.3, 45.6, 99.3)))).toArray.sameElements(expectedArray))
     }


### PR DESCRIPTION
This will fix the issue with BigDecimal making it into a VectorAssembler