### PR TITLE
Fixed up several param serialization issues with Spark.

### DIFF
--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/LogisticRegressionOp.scala
@@ -6,6 +6,7 @@ import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
 import org.apache.spark.ml.classification.LogisticRegressionModel
 import org.apache.spark.ml.linalg.Vectors
+import org.apache.spark.ml.bundle.util.ParamUtil
 
 /**
   * Created by hollinwilkins on 8/21/16.
@@ -50,9 +51,10 @@ class LogisticRegressionOp extends OpNode[SparkBundleContext, LogisticRegression
                    (implicit context: BundleContext[SparkBundleContext]): LogisticRegressionModel = {
     var lr = new LogisticRegressionModel(uid = node.name,
       coefficients = model.coefficients,
-      intercept = model.intercept).copy(model.extractParamMap).
+      intercept = model.intercept).
       setFeaturesCol(node.shape.input("features").name).
       setPredictionCol(node.shape.output("prediction").name)
+    ParamUtil.setOptional(lr, model, lr.threshold, model.threshold)
     lr = node.shape.getOutput("probability").map(p => lr.setProbabilityCol(p.name)).getOrElse(lr)
     node.shape.getOutput("raw_prediction").map(rp => lr.setRawPredictionCol(rp.name)).getOrElse(lr)
   }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/RandomForestClassifierOp.scala
@@ -68,7 +68,7 @@ class RandomForestClassifierOp extends OpNode[SparkBundleContext, RandomForestCl
       numFeatures = model.numFeatures,
       _trees = model.trees).
       setFeaturesCol(node.shape.input("features").name).
-      setPredictionCol(node.shape.input("prediction").name)
+      setPredictionCol(node.shape.output("prediction").name)
     rf = node.shape.getOutput("probability").map(p => rf.setProbabilityCol(p.name)).getOrElse(rf)
     node.shape.getOutput("raw_prediction").map(rp => rf.setRawPredictionCol(rp.name)).getOrElse(rf)
   }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/SupportVectorMachineOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/classification/SupportVectorMachineOp.scala
@@ -4,6 +4,7 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.op.{OpModel, OpNode}
 import ml.combust.bundle.dsl._
 import org.apache.spark.ml.bundle.SparkBundleContext
+import org.apache.spark.ml.bundle.util.ParamUtil
 import org.apache.spark.ml.mleap.classification.SVMModel
 import org.apache.spark.mllib.classification
 import org.apache.spark.mllib.linalg.Vectors
@@ -49,9 +50,10 @@ class SupportVectorMachineOp extends OpNode[SparkBundleContext, SVMModel, SVMMod
   override def load(node: Node, model: SVMModel)
                    (implicit context: BundleContext[SparkBundleContext]): SVMModel = {
     val svm = new SVMModel(uid = node.name,
-      model = model.model).copy(model.extractParamMap()).
+      model = model.model).
       setFeaturesCol(node.shape.input("features").name).
       setPredictionCol(node.shape.output("prediction").name)
+    ParamUtil.setOptional(svm, model, svm.threshold, model.threshold)
     node.shape.getOutput("probability").map(s => svm.setProbabilityCol(s.name)).getOrElse(svm)
   }
 

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/clustering/GaussianMixtureOp.scala
@@ -58,11 +58,17 @@ class GaussianMixtureOp extends OpNode[MleapContext, GaussianMixtureModel, Gauss
       weights = model.weights)
     gmm.set(gmm.featuresCol, node.shape.input("features").name)
     gmm.set(gmm.predictionCol, node.shape.output("prediction").name)
-    for(p <- node.shape.getOutput("probability")) { gmm.set(gmm.probabilityCol, p.name) }
+    for(p <- node.shape.getOutput("probability")) {
+      gmm.set(gmm.probabilityCol, p.name)
+    }
     gmm
   }
 
-  override def shape(node: GaussianMixtureModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
-    withOutput(node.getPredictionCol, "prediction").
-    withOutput(node.getProbabilityCol, "probability")
+  override def shape(node: GaussianMixtureModel): Shape = {
+    val probability = if(node.isSet(node.probabilityCol)) Some(node.getProbabilityCol) else None
+
+    Shape().withInput(node.getFeaturesCol, "features").
+      withOutput(node.getPredictionCol, "prediction").
+      withOutput(probability, "probability")
+  }
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BinarizerOp.scala
@@ -4,6 +4,7 @@ import ml.combust.bundle.BundleContext
 import ml.combust.bundle.dsl._
 import ml.combust.bundle.op.{OpModel, OpNode}
 import org.apache.spark.ml.bundle.SparkBundleContext
+import org.apache.spark.ml.bundle.util.ParamUtil
 import org.apache.spark.ml.feature.Binarizer
 
 /**
@@ -35,9 +36,10 @@ class BinarizerOp extends OpNode[SparkBundleContext, Binarizer, Binarizer] {
 
   override def load(node: Node, model: Binarizer)
                    (implicit context: BundleContext[SparkBundleContext]): Binarizer = {
-    new Binarizer(uid = node.name).copy(model.extractParamMap()).
+    new Binarizer(uid = node.name).
       setInputCol(node.shape.standardInput.name).
-      setOutputCol(node.shape.standardOutput.name)
+      setOutputCol(node.shape.standardOutput.name).
+      setThreshold(model.getThreshold)
   }
 
   override def shape(node: Binarizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/BucketizerOp.scala
@@ -34,9 +34,10 @@ class BucketizerOp extends OpNode[SparkBundleContext, Bucketizer, Bucketizer] {
 
   override def load(node: Node, model: Bucketizer)
                    (implicit context: BundleContext[SparkBundleContext]): Bucketizer = {
-    new Bucketizer(uid = node.name).copy(model.extractParamMap()).
+    new Bucketizer(uid = node.name).
       setInputCol(node.shape.standardInput.name).
-      setOutputCol(node.shape.standardOutput.name)
+      setOutputCol(node.shape.standardOutput.name).
+      setSplits(model.getSplits)
   }
 
   override def shape(node: Bucketizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ElementwiseProductOp.scala
@@ -36,9 +36,10 @@ class ElementwiseProductOp extends OpNode[SparkBundleContext, ElementwiseProduct
 
   override def load(node: Node, model: ElementwiseProduct)
                    (implicit context: BundleContext[SparkBundleContext]): ElementwiseProduct = {
-    new ElementwiseProduct(uid = node.name).copy(model.extractParamMap()).
+    new ElementwiseProduct(uid = node.name).
       setInputCol(node.shape.standardInput.name).
-      setOutputCol(node.shape.standardOutput.name)
+      setOutputCol(node.shape.standardOutput.name).
+      setScalingVec(model.getScalingVec)
   }
 
   override def shape(node: ElementwiseProduct): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/NormalizerOp.scala
@@ -34,9 +34,10 @@ class NormalizerOp extends OpNode[SparkBundleContext, Normalizer, Normalizer] {
 
   override def load(node: Node, model: Normalizer)
                    (implicit context: BundleContext[SparkBundleContext]): Normalizer = {
-    new Normalizer(uid = node.name).copy(model.extractParamMap()).
+    new Normalizer(uid = node.name).
       setInputCol(node.shape.standardInput.name).
-      setOutputCol(node.shape.standardOutput.name)
+      setOutputCol(node.shape.standardOutput.name).
+      setP(model.getP)
   }
 
   override def shape(node: Normalizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/ReverseStringIndexerOp.scala
@@ -34,7 +34,7 @@ class ReverseStringIndexerOp extends OpNode[SparkBundleContext, IndexToString, I
 
   override def load(node: Node, model: IndexToString)
                    (implicit context: BundleContext[SparkBundleContext]): IndexToString = {
-    new IndexToString(uid = node.name).copy(model.extractParamMap())
+    new IndexToString(uid = node.name).setLabels(model.getLabels)
   }
 
   override def shape(node: IndexToString): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/feature/TokenizerOp.scala
@@ -30,7 +30,9 @@ class TokenizerOp extends OpNode[SparkBundleContext, Tokenizer, Tokenizer] {
 
   override def load(node: Node, model: Tokenizer)
                    (implicit context: BundleContext[SparkBundleContext]): Tokenizer = {
-    new Tokenizer(uid = node.name)
+    new Tokenizer(uid = node.name).
+      setInputCol(node.shape.standardInput.name).
+      setOutputCol(node.shape.standardOutput.name)
   }
 
   override def shape(node: Tokenizer): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/GBTRegressionOp.scala
@@ -58,7 +58,9 @@ class GBTRegressionOp extends OpNode[SparkBundleContext, GBTRegressionModel, GBT
     new GBTRegressionModel(uid = node.name,
       _trees = model.trees,
       _treeWeights = model.treeWeights,
-      numFeatures = model.numFeatures)
+      numFeatures = model.numFeatures).
+      setFeaturesCol(node.shape.input("features").name).
+      setPredictionCol(node.shape.output("prediction").name)
   }
 
   override def shape(node: GBTRegressionModel): Shape = Shape().withInput(node.getFeaturesCol, "features").

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/ops/regression/RandomForestRegressionOp.scala
@@ -64,9 +64,10 @@ class RandomForestRegressionOp extends OpNode[SparkBundleContext, RandomForestRe
       numFeatures = model.numFeatures,
       _trees = model.trees).
       setFeaturesCol(node.shape.input("features").name).
-      setPredictionCol(node.shape.input("prediction").name)
+      setPredictionCol(node.shape.output("prediction").name)
   }
 
-  override def shape(node: RandomForestRegressionModel): Shape = Shape().withInput(node.getFeaturesCol, "features").
+  override def shape(node: RandomForestRegressionModel): Shape = Shape().
+    withInput(node.getFeaturesCol, "features").
     withOutput(node.getPredictionCol, "prediction")
 }

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/tree/SparkNodeWrapper.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/tree/SparkNodeWrapper.scala
@@ -61,7 +61,7 @@ object SparkNodeWrapper extends NodeWrapper[tree.Node] {
       val c = if(s.isLeft) {
         s.categories.toArray
       } else {
-        ((0 to s.numCategories).map(_.toDouble).toSet -- s.categories).toArray
+        ((0 until s.numCategories).map(_.toDouble).toSet -- s.categories).toArray
       }
       new tree.CategoricalSplit(featureIndex = s.featureIndex,
         numCategories = s.numCategories,

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/util/ParamUtil.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/util/ParamUtil.scala
@@ -1,0 +1,21 @@
+package org.apache.spark.ml.bundle.util
+
+import org.apache.spark.ml.param.{Param, Params}
+
+/**
+  * Created by hollinwilkins on 12/21/16.
+  */
+trait ParamUtil {
+  def setOptional[T](obj1: Params,
+                     obj2: Params,
+                     param1: Param[T],
+                     param2: Param[T]): Unit = {
+    if(obj2.isSet(param2)) {
+      obj1.set(param1, obj2.get(param2).get)
+    } else {
+      obj1.clear(param1)
+    }
+  }
+}
+
+object ParamUtil extends ParamUtil

--- a/mleap-spark/src/test/scala/org/apache/spark/ml/parity/clustering/GaussianMixtureParitySpec.scala
+++ b/mleap-spark/src/test/scala/org/apache/spark/ml/parity/clustering/GaussianMixtureParitySpec.scala
@@ -23,6 +23,8 @@ class GaussianMixtureParitySpec extends SparkParityBase {
   override val sparkTransformer: Transformer = {
     new GaussianMixture().
       setFeaturesCol("features").
-      setPredictionCol("prediction").fit(dataset)
+      setPredictionCol("prediction").
+      setProbabilityCol("probability"). // For some reason the tests fail when we don't set the probability column
+      fit(dataset)
   }
 }


### PR DESCRIPTION
This pull request fixes several issues we had with Spark serialization/deserialization:
1. We no longer use copy with extractParamMap to copy params from a model to the transformer, this was not working
2. Fixed a deserialization issue with Spark categorical split serialization
3. Fixed several issues with missing parameters (mostly input/output)