### PR TITLE
Fix serialization of decision trees.

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/tree/JsonSupport.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/tree/JsonSupport.scala
@@ -39,7 +39,7 @@ trait JsonSupport {
   }
 
   implicit val bundleTreeInternalNodeFormat: RootJsonFormat[InternalNode] = jsonFormat1(InternalNode.apply)
-  implicit val bundleTreeLeafNodeFormat: RootJsonFormat[LeafNode] = jsonFormat2(LeafNode.apply)
+  implicit val bundleTreeLeafNodeFormat: RootJsonFormat[LeafNode] = jsonFormat1(LeafNode.apply)
 
   implicit val bundleTreeNodeFormat: RootJsonFormat[Node] = new RootJsonFormat[Node] {
     override def write(obj: Node): JsValue = {

--- a/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/serializer/BundleSerializationSpec.scala
@@ -77,8 +77,8 @@ class BundleSerializationSpec extends FunSpec {
       describe("with a decision tree") {
         it("serializes/deserializes the same object") {
           val node = InternalNode(CategoricalSplit(1, isLeft = true, 5, Seq(1.0, 3.0)),
-            InternalNode(ContinuousSplit(2, 0.4), LeafNode(5.0, Some(Seq())), LeafNode(4.0, Some(Seq()))),
-            LeafNode(3.0, Some(Seq(0.4, 5.6, 3.2, 5.7, 5.5))))
+            InternalNode(ContinuousSplit(2, 0.4), LeafNode(Seq(5.0)), LeafNode(Seq(4.0))),
+            LeafNode(Seq(0.4, 5.6, 3.2, 5.7, 5.5)))
           val dt = DecisionTreeRegression(uid = "my_decision_tree",
             input = "my_input",
             output = "my_output",

--- a/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/DecisionTreeRegressionOp.scala
+++ b/bundle-ml/src/test/scala/ml/combust/bundle/test/ops/DecisionTreeRegressionOp.scala
@@ -17,7 +17,7 @@ case class ContinuousSplit(featureIndex: Int, threshold: Double) extends Split
 
 sealed trait Node
 case class InternalNode(split: Split, left: Node, right: Node) extends Node
-case class LeafNode(prediction: Double, impurities: Option[Seq[Double]]) extends Node
+case class LeafNode(values: Seq[Double]) extends Node
 
 case class DecisionTreeRegressionModel(root: Node)
 case class DecisionTreeRegression(uid: String,
@@ -41,19 +41,13 @@ object MyNodeWrapper extends NodeWrapper[Node] {
       }
       ml.bundle.tree.Node.Node(ml.bundle.tree.Node.Node.N.Internal(ml.bundle.tree.Node.Node.InternalNode(Some(split))))
     case node: LeafNode =>
-      val impurities = if(withImpurities) {
-        node.impurities.get
-      } else { Seq() }
-      ml.bundle.tree.Node.Node(ml.bundle.tree.Node.Node.N.Leaf(ml.bundle.tree.Node.Node.LeafNode(node.prediction, impurities)))
+      ml.bundle.tree.Node.Node(ml.bundle.tree.Node.Node.N.Leaf(ml.bundle.tree.Node.Node.LeafNode(values = node.values)))
   }
 
   override def isInternal(node: Node): Boolean = node.isInstanceOf[InternalNode]
 
   override def leaf(node: ml.bundle.tree.Node.Node.LeafNode, withImpurities: Boolean): Node = {
-    val impurities = if(withImpurities) {
-      Some(node.impurities)
-    } else { None }
-    LeafNode(node.prediction, impurities)
+    LeafNode(values = node.values)
   }
 
   override def internal(node: ml.bundle.tree.Node.Node.InternalNode, left: Node, right: Node): Node = {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/DecisionTreeClassifierModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/DecisionTreeClassifierModel.scala
@@ -14,7 +14,7 @@ case class DecisionTreeClassifierModel(override val rootNode: Node,
                                        override val numClasses: Int)
   extends MultinomialClassificationModel with DecisionTree with Serializable {
   override def predictRaw(features: Vector): Vector = {
-    rootNode.predictImpl(features).impurities.get
+    rootNode.predictImpl(features).impurities
   }
 
   override def rawToProbabilityInPlace(raw: Vector): Vector = {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/classification/RandomForestClassifierModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/classification/RandomForestClassifierModel.scala
@@ -30,7 +30,7 @@ case class RandomForestClassifierModel(override val trees: Seq[DecisionTreeClass
   override def predictRaw(raw: Vector): Vector = {
     val votes = Array.fill[Double](numClasses)(0.0)
     trees.view.foreach { tree =>
-      val classCounts: Array[Double] = tree.rootNode.predictImpl(raw).impurities.get.toArray
+      val classCounts: Array[Double] = tree.rootNode.predictImpl(raw).impurities.toArray
       val total = classCounts.sum
       if (total != 0) {
         var i = 0

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/tree/Node.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/tree/Node.scala
@@ -1,7 +1,7 @@
 package ml.combust.mleap.core.tree
 
 import ml.combust.mleap.core.annotation.SparkCode
-import org.apache.spark.ml.linalg.Vector
+import org.apache.spark.ml.linalg.{Vector, Vectors}
 
 /** Trait for a node in a decision tree.
   */
@@ -10,15 +10,21 @@ sealed trait Node extends Serializable {
   def predictImpl(features: Vector): LeafNode
 }
 
+object LeafNode {
+  def apply(values: Seq[Double]): LeafNode = LeafNode(values = Vectors.dense(values.toArray))
+  def apply(value: Double): LeafNode = LeafNode(values = Vectors.dense(Array(value)))
+}
+
 /** Trait for a leaf node in a decision tree.
   *
-  * @param prediction prediction for this leaf node
-  * @param impurities options vector of impurities
+  * @param values values vector of impurities or single prediction
   */
 @SparkCode(uri = "https://github.com/apache/spark/blob/v2.0.0/mllib/src/main/scala/org/apache/spark/ml/tree/Node.scala")
-final case class LeafNode(prediction: Double,
-                          impurities: Option[Vector] = None) extends Node {
+final case class LeafNode(values: Vector) extends Node {
   override def predictImpl(features: Vector): LeafNode = this
+
+  def prediction: Double = values(0)
+  def impurities: Vector = values
 }
 
 /** Trait for internal node in a decision tree.

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/DecisionTreeRegressionModelSpec.scala
@@ -10,14 +10,14 @@ import org.scalatest.FunSpec
 class DecisionTreeRegressionModelSpec extends FunSpec {
   describe("#predict") {
     it("returns the prediction for the decision tree") {
-      val leftNode = LeafNode(.78, None)
-      val rightNode = LeafNode(.34, None)
-      val split = ContinuousSplit(0, .5)
+      val leftNode = LeafNode(Seq(0.78))
+      val rightNode = LeafNode(Seq(0.34))
+      val split = ContinuousSplit(0, 0.5)
       val node = InternalNode(leftNode, rightNode, split)
       val features = Vectors.dense(Array(0.3, 1.0, 43.23, -21.2, 66.7))
       val regression = DecisionTreeRegressionModel(node, 5)
 
-      assert(regression.predict(features) == .78)
+      assert(regression.predict(features) == 0.78)
     }
   }
 }

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/regression/RandomForestRegressionModelSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/regression/RandomForestRegressionModelSpec.scala
@@ -11,17 +11,17 @@ import org.scalatest.FunSpec
 class RandomForestRegressionModelSpec extends FunSpec {
   describe("#predict") {
     it("uses the forest to make a prediction") {
-      val tree1 = TestUtil.buildDecisionTreeRegression(.5, 0, goLeft = true)
-      val tree2 = TestUtil.buildDecisionTreeRegression(.75, 1, goLeft = false)
-      val tree3 = TestUtil.buildDecisionTreeRegression(.1, 2, goLeft = true)
+      val tree1 = TestUtil.buildDecisionTreeRegression(0.5, 0, goLeft = true)
+      val tree2 = TestUtil.buildDecisionTreeRegression(0.75, 1, goLeft = false)
+      val tree3 = TestUtil.buildDecisionTreeRegression(0.1, 2, goLeft = true)
 
       val regression = RandomForestRegressionModel(Seq(tree1, tree2, tree3), 5)
-      val features = Vectors.dense(Array(.2, .8, .4))
+      val features = Vectors.dense(Array(0.2, 0.8, 0.4))
 
-      assert(tree1.predict(features) == .5)
-      assert(tree2.predict(features) == .75)
-      assert(tree3.predict(features) == .1)
-      assert(regression.predict(features) == (.5 + .75 + .1) / 3)
+      assert(tree1.predict(features) == 0.5)
+      assert(tree2.predict(features) == 0.75)
+      assert(tree3.predict(features) == 0.1)
+      assert(regression.predict(features) == (0.5 + 0.75 + 0.1) / 3)
     }
   }
 

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/test/TestUtil.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/test/TestUtil.scala
@@ -14,9 +14,9 @@ object TestUtil {
   }
 
   def buildTri(prediction: Double, featureIndex: Int, goLeft: Boolean): Node = {
-    val node1 = LeafNode(prediction, None)
-    val node2 = LeafNode(42.34, None)
-    val split = ContinuousSplit(featureIndex, .5)
+    val node1 = LeafNode(prediction)
+    val node2 = LeafNode(42.34)
+    val split = ContinuousSplit(featureIndex, 0.5)
 
     if(goLeft) {
       InternalNode(node1, node2, split)

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/tree/NodeSpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/tree/NodeSpec.scala
@@ -12,8 +12,8 @@ class InternalNodeSpec extends FunSpec {
   }
 
   describe("#predictImpl") {
-    val leftNode = LeafNode(.45, None)
-    val rightNode = LeafNode(.33, None)
+    val leftNode = LeafNode(0.45)
+    val rightNode = LeafNode(0.33)
     val features = Vectors.dense(Array(0.3))
 
     describe("when split goes left") {
@@ -35,8 +35,8 @@ class InternalNodeSpec extends FunSpec {
 class LeafNodeSpec extends FunSpec {
   describe("#predictImpl") {
     it("returns itself") {
-      val node = LeafNode(.45, None)
-      assert(node.predictImpl(Vectors.dense(Array(.67))) == node)
+      val node = LeafNode(0.45)
+      assert(node.predictImpl(Vectors.dense(Array(0.67))) == node)
     }
   }
 }

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/tree/MleapNodeWrapper.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/tree/MleapNodeWrapper.scala
@@ -6,7 +6,6 @@ import ml.bundle.tree.Split.Split.{CategoricalSplit, ContinuousSplit}
 import ml.bundle.tree.Node.Node
 import ml.bundle.tree.Node.Node.{InternalNode, LeafNode}
 import ml.combust.bundle.tree.NodeWrapper
-import org.apache.spark.ml.linalg.Vectors
 
 /**
   * Created by hollinwilkins on 8/22/16.
@@ -26,23 +25,13 @@ object MleapNodeWrapper extends NodeWrapper[ml.combust.mleap.core.tree.Node] {
       }
       Node(Node.N.Internal(Node.InternalNode(Some(split))))
     case node: ml.combust.mleap.core.tree.LeafNode =>
-      val impurities = if(withImpurities) {
-        node.impurities.get.toArray.toSeq
-      } else { Seq() }
-      Node(Node.N.Leaf(Node.LeafNode(node.prediction, impurities)))
+      Node(Node.N.Leaf(Node.LeafNode(node.values.toArray)))
   }
 
   override def isInternal(node: ml.combust.mleap.core.tree.Node): Boolean = node.isInstanceOf[ml.combust.mleap.core.tree.InternalNode]
 
   override def leaf(node: LeafNode, withImpurities: Boolean): ml.combust.mleap.core.tree.Node = {
-    val impurities = if(withImpurities) {
-      Some(Vectors.dense(node.impurities.toArray))
-    } else {
-      None
-    }
-
-    tree.LeafNode(prediction = node.prediction,
-      impurities = impurities)
+    tree.LeafNode(values = node.values)
   }
 
   override def internal(node: InternalNode,

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/test/TestUtil.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/test/TestUtil.scala
@@ -14,9 +14,9 @@ object TestUtil {
   }
 
   def buildTri(prediction: Double, featureIndex: Int, goLeft: Boolean): Node = {
-    val node1 = LeafNode(prediction, None)
-    val node2 = LeafNode(42.34, None)
-    val split = ContinuousSplit(featureIndex, .5)
+    val node1 = LeafNode(prediction)
+    val node2 = LeafNode(42.34)
+    val split = ContinuousSplit(featureIndex, 0.5)
 
     if(goLeft) {
       InternalNode(node1, node2, split)

--- a/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/tree/SparkNodeWrapper.scala
+++ b/mleap-spark/src/main/scala/org/apache/spark/ml/bundle/tree/SparkNodeWrapper.scala
@@ -33,21 +33,21 @@ object SparkNodeWrapper extends NodeWrapper[tree.Node] {
       }
       Node(Node.N.Internal(Node.InternalNode(Some(split))))
     case node: tree.LeafNode =>
-      val impurities = if(withImpurities) {
-        node.impurityStats.stats
-      } else { Array() }
-      Node(Node.N.Leaf(Node.LeafNode(node.prediction, impurities)))
+      val values = if(withImpurities) {
+        node.impurityStats.stats.toSeq
+      } else { Seq(node.prediction) }
+      Node(Node.N.Leaf(Node.LeafNode(values)))
   }
 
   override def isInternal(node: tree.Node): Boolean = node.isInstanceOf[tree.InternalNode]
 
   override def leaf(node: LeafNode, withImpurities: Boolean): tree.Node = {
     val calc: ImpurityCalculator = if(withImpurities) {
-      ImpurityCalculator.getCalculator("gini", node.impurities.toArray)
+      ImpurityCalculator.getCalculator("gini", node.values.toArray)
     } else {
       null
     }
-    new tree.LeafNode(prediction = node.prediction,
+    new tree.LeafNode(prediction = node.values.head,
       impurity = 0.0,
       impurityStats = calc)
   }


### PR DESCRIPTION
Do not store impurities/prediction separately, instead store a "values" array.