### PR TITLE
Feature/issue65 - Unary/Binary math operations

### DIFF
--- a/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
+++ b/bundle-ml/src/main/scala/ml/combust/bundle/dsl/Bundle.scala
@@ -37,6 +37,8 @@ object Bundle {
 
     object feature {
       val binarizer = "binarizer"
+      val math_unary = "math_unary"
+      val math_binary = "math_binary"
       val string_indexer = "string_indexer"
       val chi_sq_selector = "chi_sq_selector"
       val reverse_string_indexer = "reverse_string_indexer"

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala
@@ -1,0 +1,56 @@
+package ml.combust.mleap.core.feature
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+sealed trait BinaryOperation {
+  def name: String
+}
+object BinaryOperation {
+  case object Add extends BinaryOperation {
+    override def name: String = "add"
+  }
+  case object Subtract extends BinaryOperation {
+    override def name: String = "sub"
+  }
+  case object Multiply extends BinaryOperation {
+    override def name: String = "mul"
+  }
+  case object Divide extends BinaryOperation {
+    override def name: String = "div"
+  }
+  case object Remainder extends BinaryOperation {
+    override def name: String = "rem"
+  }
+  case object LogN extends BinaryOperation {
+    override def name: String = "log_n"
+  }
+  case object Pow extends BinaryOperation {
+    override def name: String = "pow"
+  }
+
+  val all = Set(Add, Subtract, Multiply, Divide, Remainder, LogN, Pow)
+  val forName: Map[String, BinaryOperation] = all.map(o => (o.name, o)).toMap
+}
+
+case class MathBinaryModel(operation: BinaryOperation,
+                           da: Option[Double] = None,
+                           db: Option[Double] = None) {
+  import BinaryOperation._
+
+  def apply(ma: Option[Double], mb: Option[Double]): Double = {
+    val a = ma.getOrElse(da.get)
+    val b = mb.getOrElse(db.get)
+
+    operation match {
+      case Add => a + b
+      case Subtract => a - b
+      case Multiply => a * b
+      case Divide => a / b
+      case Remainder => a % b
+      case LogN => Math.log(a) / Math.log(b)
+      case Pow => Math.pow(a, b)
+      case _ => throw new RuntimeException(s"unsupported binary operation $operation")
+    }
+  }
+}

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathBinaryModel.scala
@@ -3,7 +3,7 @@ package ml.combust.mleap.core.feature
 /**
   * Created by hollinwilkins on 12/27/16.
   */
-sealed trait BinaryOperation {
+sealed trait BinaryOperation extends Serializable {
   def name: String
 }
 object BinaryOperation {
@@ -35,7 +35,7 @@ object BinaryOperation {
 
 case class MathBinaryModel(operation: BinaryOperation,
                            da: Option[Double] = None,
-                           db: Option[Double] = None) {
+                           db: Option[Double] = None) extends Serializable {
   import BinaryOperation._
 
   def apply(ma: Option[Double], mb: Option[Double]): Double = {

--- a/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathUnaryModel.scala
+++ b/mleap-core/src/main/scala/ml/combust/mleap/core/feature/MathUnaryModel.scala
@@ -1,0 +1,45 @@
+package ml.combust.mleap.core.feature
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+sealed trait UnaryOperation {
+  def name: String
+}
+object UnaryOperation {
+  case object Log extends UnaryOperation {
+    override def name: String = "log"
+  }
+  case object Exp extends UnaryOperation {
+    override def name: String = "exp"
+  }
+  case object Sqrt extends UnaryOperation {
+    override def name: String = "sqrt"
+  }
+  case object Sin extends UnaryOperation {
+    override def name: String = "sin"
+  }
+  case object Cos extends UnaryOperation {
+    override def name: String = "cos"
+  }
+  case object Tan extends UnaryOperation {
+    override def name: String = "tan"
+  }
+
+  val all = Set(Log, Exp, Sqrt, Sin, Cos, Tan)
+  val forName: Map[String, UnaryOperation] = all.map(o => (o.name, o)).toMap
+}
+
+case class MathUnaryModel(operation: UnaryOperation) {
+  import UnaryOperation._
+
+  def apply(a: Double): Double = operation match {
+    case Log => Math.log(a)
+    case Exp => Math.exp(a)
+    case Sqrt => Math.sqrt(a)
+    case Sin => Math.sin(a)
+    case Cos => Math.cos(a)
+    case Tan => Math.tan(a)
+    case _ => throw new RuntimeException(s"unsupported unary operation: $operation")
+  }
+}

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathBinarySpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathBinarySpec.scala
@@ -1,0 +1,29 @@
+package ml.combust.mleap.core.feature
+
+import ml.combust.mleap.core.feature.BinaryOperation._
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathBinarySpec extends FunSpec {
+  def binaryLike(operation: BinaryOperation,
+                 name: String,
+                 a: Double,
+                 b: Double,
+                 expected: Double): Unit = {
+    describe(operation.getClass.getSimpleName.dropRight(1)) {
+      val model = MathBinaryModel(operation, None, None)
+      it(s"has the name: $name") { assert(operation.name == name) }
+      it("calculated the value properly") { assert(model(Some(a), Some(b)) == expected) }
+    }
+  }
+
+  binaryLike(Add, "add", 3.0, 6.7, 3.0 + 6.7)
+  binaryLike(Subtract, "sub", 3.0, 6.7, 3.0 - 6.7)
+  binaryLike(Multiply, "mul", 3.0, 6.7, 3.0 * 6.7)
+  binaryLike(Divide, "div", 3.0, 6.7, 3.0 / 6.7)
+  binaryLike(Remainder, "rem", 3.0, 6.7, 3.0 % 6.7)
+  binaryLike(LogN, "log_n", 3.0, 6.7, Math.log(3.0) / Math.log(6.7))
+  binaryLike(Pow, "pow", 3.0, 6.7, Math.pow(3.0, 6.7))
+}

--- a/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnarySpec.scala
+++ b/mleap-core/src/test/scala/ml/combust/mleap/core/feature/MathUnarySpec.scala
@@ -1,0 +1,28 @@
+package ml.combust.mleap.core.feature
+
+import ml.combust.mleap.core.feature.UnaryOperation._
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathUnarySpec extends FunSpec {
+  def unaryLike(operation: UnaryOperation,
+                name: String,
+                input: Double,
+                expected: Double): Unit = {
+    describe(operation.getClass.getSimpleName.dropRight(1)) {
+      val model = MathUnaryModel(operation)
+
+      it(s"has the name: $name") { assert(operation.name == name) }
+      it("computes the value properly") { assert(model(input) == expected) }
+    }
+  }
+
+  unaryLike(Log, "log", 65.3, Math.log(65.3))
+  unaryLike(Exp, "exp", 42.0, Math.exp(42.0))
+  unaryLike(Sqrt, "sqrt", 9.667, Math.sqrt(9.667))
+  unaryLike(Sin, "sin", 45.2, Math.sin(45.2))
+  unaryLike(Cos, "cos", 9982.2, Math.cos(9982.2))
+  unaryLike(Tan, "tan", 88777.777, Math.tan(88777.777))
+}

--- a/mleap-runtime/src/main/resources/reference.conf
+++ b/mleap-runtime/src/main/resources/reference.conf
@@ -16,6 +16,8 @@ ml.combust.bundle.registry.mleap.ops = [
   "ml.combust.mleap.bundle.ops.feature.ChiSqSelectorOp",
   "ml.combust.mleap.bundle.ops.feature.ElementwiseProductOp",
   "ml.combust.mleap.bundle.ops.feature.HashingTermFrequencyOp",
+  "ml.combust.mleap.bundle.ops.feature.MathBinaryOp",
+  "ml.combust.mleap.bundle.ops.feature.MathUnaryOp",
   "ml.combust.mleap.bundle.ops.feature.MaxAbsScalerOp",
   "ml.combust.mleap.bundle.ops.feature.MinMaxScalerOp",
   "ml.combust.mleap.bundle.ops.feature.NGramOp",

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathBinaryOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathBinaryOp.scala
@@ -1,0 +1,52 @@
+package ml.combust.mleap.bundle.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.mleap.core.feature.{BinaryOperation, MathBinaryModel}
+import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.runtime.transformer.feature.MathBinary
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
+  override val Model: OpModel[MleapContext, MathBinaryModel] = new OpModel[MleapContext, MathBinaryModel] {
+    override val klazz: Class[MathBinaryModel] = classOf[MathBinaryModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.math_binary
+
+    override def store(model: Model, obj: MathBinaryModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      model.withAttr("operation", Value.string(obj.operation.name)).
+        withAttr("da", obj.da.map(Value.double)).
+        withAttr("db", obj.db.map(Value.double))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): MathBinaryModel = {
+      MathBinaryModel(operation = BinaryOperation.forName(model.value("operation").getString),
+        da = model.getValue("da").map(_.getDouble),
+        db = model.getValue("db").map(_.getDouble))
+    }
+  }
+
+  override val klazz: Class[MathBinary] = classOf[MathBinary]
+
+  override def name(node: MathBinary): String = node.uid
+
+  override def model(node: MathBinary): MathBinaryModel = node.model
+
+  override def load(node: Node, model: MathBinaryModel)
+                   (implicit context: BundleContext[MleapContext]): MathBinary = {
+    MathBinary(uid = node.name,
+      inputA = node.shape.getInput("input_a").map(_.name),
+      inputB = node.shape.getInput("input_b").map(_.name),
+      outputCol = node.shape.standardOutput.name,
+      model = model)
+  }
+
+  override def shape(node: MathBinary): Shape = Shape().withInput(node.inputA, "input_a").
+    withInput(node.inputB, "input_b").
+    withStandardOutput(node.outputCol)
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathUnaryOp.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/bundle/ops/feature/MathUnaryOp.scala
@@ -1,0 +1,45 @@
+package ml.combust.mleap.bundle.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.mleap.core.feature.{MathUnaryModel, UnaryOperation}
+import ml.combust.mleap.runtime.MleapContext
+import ml.combust.mleap.runtime.transformer.feature.MathUnary
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
+  override val Model: OpModel[MleapContext, MathUnaryModel] = new OpModel[MleapContext, MathUnaryModel] {
+    override val klazz: Class[MathUnaryModel] = classOf[MathUnaryModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.math_unary
+
+    override def store(model: Model, obj: MathUnaryModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      model.withAttr("operation", Value.string(obj.operation.name))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): MathUnaryModel = {
+      MathUnaryModel(UnaryOperation.forName(model.value("operation").getString))
+    }
+  }
+
+  override val klazz: Class[MathUnary] = classOf[MathUnary]
+
+  override def name(node: MathUnary): String = node.uid
+
+  override def model(node: MathUnary): MathUnaryModel = node.model
+
+  override def load(node: Node, model: MathUnaryModel)
+                   (implicit context: BundleContext[MleapContext]): MathUnary = {
+    MathUnary(uid = node.name,
+      inputCol = node.shape.standardInput.name,
+      outputCol = node.shape.standardOutput.name,
+      model = model)
+  }
+
+  override def shape(node: MathUnary): Shape = Shape().withStandardIO(node.inputCol, node.outputCol)
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MathBinary.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MathBinary.scala
@@ -15,9 +15,9 @@ case class MathBinary(override val uid: String = Transformer.uniqueName("math_bi
                       inputB: Option[String] = None,
                       outputCol: String,
                       model: MathBinaryModel) extends Transformer {
+  val execAB: UserDefinedFunction = (a: Double, b: Double) => model(Some(a), Some(b))
   val execA: UserDefinedFunction = (a: Double) => model(Some(a), None)
   val execB: UserDefinedFunction = (b: Double) => model(None, Some(b))
-  val execAB: UserDefinedFunction = (a: Double, b: Double) => model(Some(a), Some(b))
   val execNone: UserDefinedFunction = () => model(None, None)
 
   override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MathBinary.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MathBinary.scala
@@ -1,0 +1,31 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.MathBinaryModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.Transformer
+import ml.combust.mleap.runtime.transformer.builder.TransformBuilder
+
+import scala.util.Try
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+case class MathBinary(override val uid: String = Transformer.uniqueName("math_binary"),
+                      inputA: Option[String] = None,
+                      inputB: Option[String] = None,
+                      outputCol: String,
+                      model: MathBinaryModel) extends Transformer {
+  val execA: UserDefinedFunction = (a: Double) => model(Some(a), None)
+  val execB: UserDefinedFunction = (b: Double) => model(None, Some(b))
+  val execAB: UserDefinedFunction = (a: Double, b: Double) => model(Some(a), Some(b))
+  val execNone: UserDefinedFunction = () => model(None, None)
+
+  override def transform[TB <: TransformBuilder[TB]](builder: TB): Try[TB] = {
+    (inputA, inputB) match {
+      case (Some(a), Some(b)) => builder.withOutput(outputCol, a, b)(execAB)
+      case (Some(a), None) => builder.withOutput(outputCol, a)(execA)
+      case (None, Some(b)) => builder.withOutput(outputCol, b)(execB)
+      case (None, None) => builder.withOutput(outputCol)(execNone)
+    }
+  }
+}

--- a/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MathUnary.scala
+++ b/mleap-runtime/src/main/scala/ml/combust/mleap/runtime/transformer/feature/MathUnary.scala
@@ -1,0 +1,15 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.MathUnaryModel
+import ml.combust.mleap.runtime.function.UserDefinedFunction
+import ml.combust.mleap.runtime.transformer.{FeatureTransformer, Transformer}
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+case class MathUnary(override val uid: String = Transformer.uniqueName("math_unary"),
+                     override val inputCol: String,
+                     override val outputCol: String,
+                     model: MathUnaryModel) extends FeatureTransformer {
+  override val exec: UserDefinedFunction = (a: Double) => model(a)
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathBinarySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathBinarySpec.scala
@@ -1,0 +1,60 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.BinaryOperation._
+import ml.combust.mleap.core.feature.MathBinaryModel
+import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
+import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType}
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathBinarySpec extends FunSpec {
+  val schema = StructType(StructField("test_a", DoubleType), StructField("test_b", DoubleType)).get
+  val dataset = LocalDataset(Seq(Row(5.6, 7.9)))
+  val frame = LeapFrame(schema, dataset)
+
+  describe("with a and b inputs") {
+    val model = MathBinary(inputA = Some("test_a"),
+      inputB = Some("test_b"),
+      outputCol = "test_out",
+      model = MathBinaryModel(Divide, None, None))
+
+    it("calculates the correct value") {
+      val calc = model.transform(frame).get.dataset(0).getDouble(2)
+      assert(calc == 5.6 / 7.9)
+    }
+  }
+
+  describe("with a input") {
+    val model = MathBinary(inputA = Some("test_a"),
+      outputCol = "test_out",
+      model = MathBinaryModel(Multiply, None, Some(3.333)))
+
+    it("calculates the value using the b default") {
+      val calc = model.transform(frame).get.dataset(0).getDouble(2)
+      assert(calc == 5.6 * 3.333)
+    }
+  }
+
+  describe("with b input") {
+    val model = MathBinary(inputB = Some("test_b"),
+      outputCol = "test_out",
+      model = MathBinaryModel(Multiply, Some(3.333), None))
+
+    it("calculates the value using the a default") {
+      val calc = model.transform(frame).get.dataset(0).getDouble(2)
+      assert(calc == 3.333 * 7.9)
+    }
+  }
+
+  describe("with no inputs") {
+    val model = MathBinary(outputCol = "test_out",
+      model = MathBinaryModel(Multiply, Some(3.333), Some(5.223)))
+
+    it("calculates the value using the a default") {
+      val calc = model.transform(frame).get.dataset(0).getDouble(2)
+      assert(calc == 3.333 * 5.223)
+    }
+  }
+}

--- a/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathUnarySpec.scala
+++ b/mleap-runtime/src/test/scala/ml/combust/mleap/runtime/transformer/feature/MathUnarySpec.scala
@@ -1,0 +1,27 @@
+package ml.combust.mleap.runtime.transformer.feature
+
+import ml.combust.mleap.core.feature.MathUnaryModel
+import ml.combust.mleap.core.feature.UnaryOperation.Sin
+import ml.combust.mleap.runtime.{LeapFrame, LocalDataset, Row}
+import ml.combust.mleap.runtime.types.{DoubleType, StructField, StructType}
+import org.scalatest.FunSpec
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathUnarySpec extends FunSpec {
+  val schema = StructType(StructField("test_a", DoubleType)).get
+  val dataset = LocalDataset(Seq(Row(42.0)))
+  val frame = LeapFrame(schema, dataset)
+
+  describe("#transform") {
+    val model = MathUnary(inputCol = "test_a",
+      outputCol = "test_out",
+      model = MathUnaryModel(Sin))
+
+    it("transforms the leap frame using the given input and operation") {
+      val calc = model.transform(frame).get.dataset(0).getDouble(1)
+      assert(calc == Math.sin(42.0))
+    }
+  }
+}

--- a/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
+++ b/mleap-spark-base/src/main/scala/org/apache/spark/sql/mleap/UserDefinedFunctionConverters.scala
@@ -31,16 +31,16 @@ trait UserDefinedFunctionConverters {
         val f = udf.f.asInstanceOf[(Any) => Any]
         (a1: Any) => f(c.head(a1))
       case 2 =>
-        val f = udf.f.asInstanceOf[(Any) => Any]
+        val f = udf.f.asInstanceOf[(Any, Any) => Any]
         (a1: Any, a2: Any) => f(c.head(a1), c(1)(a2))
       case 3 =>
-        val f = udf.f.asInstanceOf[(Any) => Any]
+        val f = udf.f.asInstanceOf[(Any, Any, Any) => Any]
         (a1: Any, a2: Any, a3: Any) => f(c.head(a1), c(1)(a2), c(2)(a3))
       case 4 =>
-        val f = udf.f.asInstanceOf[(Any) => Any]
+        val f = udf.f.asInstanceOf[(Any, Any, Any, Any) => Any]
         (a1: Any, a2: Any, a3: Any, a4: Any) => f(c.head(a1), c(1)(a2), c(2)(a3), c(3)(a4))
       case 5 =>
-        val f = udf.f.asInstanceOf[(Any) => Any]
+        val f = udf.f.asInstanceOf[(Any, Any, Any, Any, Any) => Any]
         (a1: Any, a2: Any, a3: Any, a4: Any, a5: Any) => f(c.head(a1), c(1)(a2), c(2)(a3), c(3)(a4), c(4)(a5))
     }
   }

--- a/mleap-spark-extension/src/main/resources/reference.conf
+++ b/mleap-spark-extension/src/main/resources/reference.conf
@@ -1,4 +1,6 @@
 ml.combust.bundle.registry.spark.ops += "org.apache.spark.ml.bundle.extension.ops.classification.OneVsRestOp"
 ml.combust.bundle.registry.spark.ops += "org.apache.spark.ml.bundle.extension.ops.classification.SupportVectorMachineOp"
 
+ml.combust.bundle.registry.spark.ops += "org.apache.spark.ml.bundle.extension.ops.feature.MathBinaryOp"
+ml.combust.bundle.registry.spark.ops += "org.apache.spark.ml.bundle.extension.ops.feature.MathUnaryOp"
 ml.combust.bundle.registry.spark.ops += "org.apache.spark.ml.bundle.extension.ops.feature.OneHotEncoderOp"

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
@@ -1,0 +1,62 @@
+package org.apache.spark.ml.bundle.extension.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.mleap.core.feature.{BinaryOperation, MathBinaryModel}
+import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.mleap.feature.MathBinary
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
+  override val Model: OpModel[MleapContext, MathBinaryModel] = new OpModel[MleapContext, MathBinaryModel] {
+    override val klazz: Class[MathBinaryModel] = classOf[MathBinaryModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.math_binary
+
+    override def store(model: Model, obj: MathBinaryModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      model.withAttr("operation", Value.string(obj.operation.name)).
+        withAttr("da", obj.da.map(Value.double)).
+        withAttr("db", obj.db.map(Value.double))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): MathBinaryModel = {
+      MathBinaryModel(operation = BinaryOperation.forName(model.value("operation").getString),
+        da = model.getValue("da").map(_.getDouble),
+        db = model.getValue("db").map(_.getDouble))
+    }
+  }
+
+  override val klazz: Class[MathBinary] = classOf[MathBinary]
+
+  override def name(node: MathBinary): String = node.uid
+
+  override def model(node: MathBinary): MathBinaryModel = node.model
+
+  override def load(node: Node, model: MathBinaryModel)
+                   (implicit context: BundleContext[MleapContext]): MathBinary = {
+    val mb = new MathBinary(uid = node.name,
+      model = model).setOutputCol(node.shape.standardOutput.name)
+    node.shape.getInput("input_a").foreach(a => mb.setInputA(a.name))
+    node.shape.getInput("input_b").foreach(b => mb.setInputB(b.name))
+    mb
+  }
+
+  override def shape(node: MathBinary): Shape = {
+    var shape = Shape().withStandardOutput(node.getOutputCol)
+
+    if(node.isSet(node.inputA)) {
+      shape = shape.withInput(node.getInputA, "input_a")
+    }
+
+    if(node.isSet(node.inputB)) {
+      shape = shape.withInput(node.getInputB, "input_B")
+    }
+
+    shape
+  }
+}

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathBinaryOp.scala
@@ -54,7 +54,7 @@ class MathBinaryOp extends OpNode[MleapContext, MathBinary, MathBinaryModel] {
     }
 
     if(node.isSet(node.inputB)) {
-      shape = shape.withInput(node.getInputB, "input_B")
+      shape = shape.withInput(node.getInputB, "input_b")
     }
 
     shape

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/bundle/extension/ops/feature/MathUnaryOp.scala
@@ -1,0 +1,44 @@
+package org.apache.spark.ml.bundle.extension.ops.feature
+
+import ml.combust.bundle.BundleContext
+import ml.combust.bundle.dsl._
+import ml.combust.bundle.op.{OpModel, OpNode}
+import ml.combust.mleap.core.feature.{MathUnaryModel, UnaryOperation}
+import ml.combust.mleap.runtime.MleapContext
+import org.apache.spark.ml.mleap.feature.MathUnary
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathUnaryOp extends OpNode[MleapContext, MathUnary, MathUnaryModel] {
+  override val Model: OpModel[MleapContext, MathUnaryModel] = new OpModel[MleapContext, MathUnaryModel] {
+    override val klazz: Class[MathUnaryModel] = classOf[MathUnaryModel]
+
+    override def opName: String = Bundle.BuiltinOps.feature.math_unary
+
+    override def store(model: Model, obj: MathUnaryModel)
+                      (implicit context: BundleContext[MleapContext]): Model = {
+      model.withAttr("operation", Value.string(obj.operation.name))
+    }
+
+    override def load(model: Model)
+                     (implicit context: BundleContext[MleapContext]): MathUnaryModel = {
+      MathUnaryModel(UnaryOperation.forName(model.value("operation").getString))
+    }
+  }
+
+  override val klazz: Class[MathUnary] = classOf[MathUnary]
+
+  override def name(node: MathUnary): String = node.uid
+
+  override def model(node: MathUnary): MathUnaryModel = node.model
+
+  override def load(node: Node, model: MathUnaryModel)
+                   (implicit context: BundleContext[MleapContext]): MathUnary = {
+    new MathUnary(uid = node.name,
+      model = model).setInputCol(node.shape.standardInput.name).
+      setOutputCol(node.shape.standardOutput.name)
+  }
+
+  override def shape(node: MathUnary): Shape = Shape().withStandardIO(node.getInputCol, node.getOutputCol)
+}

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathBinary.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathBinary.scala
@@ -1,0 +1,75 @@
+package org.apache.spark.ml.mleap.feature
+
+import ml.combust.mleap.core.feature.MathBinaryModel
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.param.{Param, ParamMap}
+import org.apache.spark.ml.param.shared.HasOutputCol
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.types.{DoubleType, NumericType, StructField, StructType}
+import org.apache.spark.sql.functions.udf
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+trait MathBinaryParams extends HasOutputCol {
+  final val inputA: Param[String] = new Param[String](this, "inputA", "input for left side of binary operation")
+  final def getInputA: String = $(outputCol)
+
+  final val inputB: Param[String] = new Param[String](this, "inputB", "input for right side of binary operation")
+  final def getInputB: String = $(inputB)
+}
+
+class MathBinary(override val uid: String = Identifiable.randomUID("math_binary"),
+                 val model: MathBinaryModel) extends Transformer
+with MathBinaryParams {
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+  def setInputA(value: String): this.type = set(inputA, value)
+  def setInputB(value: String): this.type = set(inputB, value)
+
+  @org.apache.spark.annotation.Since("2.0.0")
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val binaryUdfA = udf {
+      (a: Double) => model(Some(a), None)
+    }
+    val binaryUdfB = udf {
+      (b: Double) => model(None, Some(b))
+    }
+    val binaryUdfAB = udf {
+      (a: Double, b: Double) => model(Some(a), Some(b))
+    }
+    val binaryUdfNone = udf {
+      () => model(None, None)
+    }
+
+    (isSet(inputA), isSet(inputB)) match {
+      case (true, true) => dataset.withColumn($(outputCol), binaryUdfAB(dataset($(inputA)).cast(DoubleType),
+        dataset($(inputB)).cast(DoubleType)))
+      case (true, false) => dataset.withColumn($(outputCol), binaryUdfA(dataset($(inputA)).cast(DoubleType)))
+      case (false, true) => dataset.withColumn($(outputCol), binaryUdfB(dataset($(inputB)).cast(DoubleType)))
+      case (false, false) => dataset.withColumn($(outputCol), binaryUdfNone())
+    }
+  }
+
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+
+  @DeveloperApi
+  override def transformSchema(schema: StructType): StructType = {
+    if(isSet(inputA)) {
+      require(schema($(inputA)).dataType.isInstanceOf[NumericType],
+        s"Input column A must be of type NumericType but got ${schema($(inputA)).dataType}")
+    }
+
+    if(isSet(inputB)) {
+      require(schema($(inputB)).dataType.isInstanceOf[NumericType],
+        s"Input column B must be of type NumericType but got ${schema($(inputB)).dataType}")
+    }
+
+    val inputFields = schema.fields
+    require(!inputFields.exists(_.name == $(outputCol)),
+      s"Output column ${$(outputCol)} already exists.")
+
+    StructType(schema.fields :+ StructField($(outputCol), DoubleType))
+  }
+}

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathBinary.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathBinary.scala
@@ -15,7 +15,7 @@ import org.apache.spark.sql.functions.udf
   */
 trait MathBinaryParams extends HasOutputCol {
   final val inputA: Param[String] = new Param[String](this, "inputA", "input for left side of binary operation")
-  final def getInputA: String = $(outputCol)
+  final def getInputA: String = $(inputA)
 
   final val inputB: Param[String] = new Param[String](this, "inputB", "input for right side of binary operation")
   final def getInputB: String = $(inputB)

--- a/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathUnary.scala
+++ b/mleap-spark-extension/src/main/scala/org/apache/spark/ml/mleap/feature/MathUnary.scala
@@ -1,0 +1,44 @@
+package org.apache.spark.ml.mleap.feature
+
+import ml.combust.mleap.core.feature.MathUnaryModel
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.ml.Transformer
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.shared.{HasInputCol, HasOutputCol}
+import org.apache.spark.ml.util.Identifiable
+import org.apache.spark.sql.{DataFrame, Dataset}
+import org.apache.spark.sql.types.{DoubleType, NumericType, StructField, StructType}
+import org.apache.spark.sql.functions.udf
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathUnary(override val uid: String = Identifiable.randomUID("math_unary"),
+                val model: MathUnaryModel) extends Transformer
+  with HasInputCol
+  with HasOutputCol {
+  def setInputCol(value: String): this.type = set(inputCol, value)
+  def setOutputCol(value: String): this.type = set(outputCol, value)
+
+  @org.apache.spark.annotation.Since("2.0.0")
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    val unaryUdf = udf {
+      (a: Double) => model(a)
+    }
+
+    dataset.withColumn($(outputCol), unaryUdf(dataset($(inputCol)).cast(DoubleType)))
+  }
+
+  override def copy(extra: ParamMap): Transformer = defaultCopy(extra)
+
+  @DeveloperApi
+  override def transformSchema(schema: StructType): StructType = {
+    require(schema($(inputCol)).dataType.isInstanceOf[NumericType],
+      s"Input column must be of type NumericType but got ${schema($(inputCol)).dataType}")
+    val inputFields = schema.fields
+    require(!inputFields.exists(_.name == $(outputCol)),
+      s"Output column ${$(outputCol)} already exists.")
+
+    StructType(schema.fields :+ StructField($(outputCol), DoubleType))
+  }
+}

--- a/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/MathBinaryParitySpec.scala
+++ b/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/MathBinaryParitySpec.scala
@@ -1,0 +1,24 @@
+package org.apache.spark.ml.mleap.parity.feature
+
+import ml.combust.mleap.core.feature.BinaryOperation.Multiply
+import ml.combust.mleap.core.feature.MathBinaryModel
+import org.apache.spark.ml.feature.StringIndexer
+import org.apache.spark.ml.mleap.feature.MathBinary
+import org.apache.spark.ml.{Pipeline, Transformer}
+import org.apache.spark.ml.parity.SparkParityBase
+import org.apache.spark.sql._
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathBinaryParitySpec extends SparkParityBase {
+  override val dataset: DataFrame = baseDataset.select("fico_score_group_fnl", "dti", "approved")
+  override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new StringIndexer().
+    setInputCol("fico_score_group_fnl").
+    setOutputCol("fico_index"),
+    new MathBinary(uid = "math_bin", model = MathBinaryModel(Multiply)).
+      setInputA("fico_index").
+      setInputB("dti").
+      setOutputCol("bin_out")
+  )).fit(dataset)
+}

--- a/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/MathUnaryParitySpec.scala
+++ b/mleap-spark-extension/src/test/scala/org/apache/spark/ml/mleap/parity/feature/MathUnaryParitySpec.scala
@@ -1,0 +1,23 @@
+package org.apache.spark.ml.mleap.parity.feature
+
+import ml.combust.mleap.core.feature.MathUnaryModel
+import ml.combust.mleap.core.feature.UnaryOperation.Tan
+import org.apache.spark.ml.feature.StringIndexer
+import org.apache.spark.ml.mleap.feature.MathUnary
+import org.apache.spark.ml.{Pipeline, Transformer}
+import org.apache.spark.ml.parity.SparkParityBase
+import org.apache.spark.sql._
+
+/**
+  * Created by hollinwilkins on 12/27/16.
+  */
+class MathUnaryParitySpec extends SparkParityBase {
+  override val dataset: DataFrame = baseDataset.select("fico_score_group_fnl", "dti", "approved")
+  override val sparkTransformer: Transformer = new Pipeline().setStages(Array(new StringIndexer().
+    setInputCol("fico_score_group_fnl").
+    setOutputCol("fico_index"),
+    new MathUnary(uid = "math_bin", model = MathUnaryModel(Tan)).
+      setInputCol("dti").
+      setOutputCol("dti_tan")
+  )).fit(dataset)
+}


### PR DESCRIPTION
Changes:
1. Added in Unary/Binary MLeap transformer and core models
2. Added in Unary/Binary Spark transformers to mleap-spark-extension model
3. Added in lots of test coverage for everything

Unary Operations Supported:
Log, Exp, Sqrt, Sin, Cos, Tan

Binary Operations Supported:
Add, Subtract, Multiply, Divide, Remainder, LogN, Pow